### PR TITLE
 Media information and tags support.

### DIFF
--- a/lib/gst/player/Makefile.am
+++ b/lib/gst/player/Makefile.am
@@ -1,7 +1,11 @@
 lib_LTLIBRARIES = libgstplayer-@GST_PLAYER_API_VERSION@.la
 
 libgstplayer_@GST_PLAYER_API_VERSION@_la_SOURCES = \
-	gstplayer.c
+	gstplayer.c \
+	gstplayer-media-info.c \
+	gstplayer-audio-stream-info.c \
+	gstplayer-video-stream-info.c \
+	gstplayer-text-stream-info.c
 
 libgstplayer_@GST_PLAYER_API_VERSION@_la_CFLAGS = \
 	-I$(top_srcdir)/lib \
@@ -24,7 +28,11 @@ libgstplayerdir = $(includedir)/gst-player-@GST_PLAYER_API_VERSION@/gst/player
 
 libgstplayer_HEADERS = \
 	player.h \
-	gstplayer.h
+	gstplayer.h \
+	gstplayer-media-info.h \
+	gstplayer-audio-stream-info.h \
+	gstplayer-video-stream-info.h \
+	gstplayer-text-stream-info.h
 
 CLEANFILES =
 

--- a/lib/gst/player/gstplayer-audio-stream-info.c
+++ b/lib/gst/player/gstplayer-audio-stream-info.c
@@ -1,0 +1,99 @@
+/* GStreamer
+ *
+ * Copyright (C) 2014 Sebastian Dröge <sebastian@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstplayer-audio-stream-info.h"
+
+struct _GstPlayerAudioStreamInfo
+{
+  gint index;
+  GstTagList *tags;
+};
+
+G_DEFINE_BOXED_TYPE (GstPlayerAudioStreamInfo, gst_player_audio_stream_info,
+    gst_player_audio_stream_info_copy, gst_player_audio_stream_info_free);
+
+
+GstPlayerAudioStreamInfo *
+gst_player_audio_stream_info_new (gint index, GstTagList * tags)
+{
+  GstPlayerAudioStreamInfo *info = NULL;
+
+  info  = g_slice_new0 (GstPlayerAudioStreamInfo);
+  info->index = index;
+
+  if (tags)
+    info->tags = gst_tag_list_ref (tags);
+
+  return info;
+}
+
+void
+gst_player_audio_stream_info_free (GstPlayerAudioStreamInfo * audioinfo)
+{
+  audioinfo->index = -1;
+  gst_tag_list_unref (audioinfo->tags);
+  g_slice_free (GstPlayerAudioStreamInfo, audioinfo);
+}
+
+GstPlayerAudioStreamInfo *
+gst_player_audio_stream_info_copy (GstPlayerAudioStreamInfo * audioinfo)
+{
+  GstPlayerAudioStreamInfo *info = NULL;
+
+  g_return_val_if_fail (audioinfo != NULL, NULL);
+
+  info = gst_player_audio_stream_info_new (audioinfo->index, audioinfo->tags);
+
+  return info;
+}
+
+gboolean
+gst_player_audio_stream_info_get_title (GstPlayerAudioStreamInfo * audioinfo,
+                                        gchar ** val)
+{
+  gboolean ret;
+
+  g_return_val_if_fail (audioinfo != NULL, FALSE);
+
+  ret = gst_tag_list_get_string (audioinfo->tags, GST_TAG_TITLE, val);
+
+  return ret;
+}
+
+gboolean
+gst_player_audio_stream_info_get_lang_code (GstPlayerAudioStreamInfo * audioinfo,
+                                            gchar ** val)
+{
+  gboolean ret;
+
+  g_return_val_if_fail (audioinfo != NULL, FALSE);
+
+  ret = gst_tag_list_get_string (audioinfo->tags, GST_TAG_LANGUAGE_CODE, val);
+
+  return ret;
+}
+
+gint
+gst_player_audio_stream_info_get_index (GstPlayerAudioStreamInfo * audioinfo)
+{
+  g_return_val_if_fail (audioinfo != NULL, -1);
+
+  return audioinfo->index;
+}

--- a/lib/gst/player/gstplayer-audio-stream-info.h
+++ b/lib/gst/player/gstplayer-audio-stream-info.h
@@ -1,0 +1,44 @@
+/* GStreamer
+ *
+ * Copyright (C) 2014 Sebastian Dröge <sebastian@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_PLAYER_AUDIO_STREAM_INFO_H__
+#define __GST_PLAYER_AUDIO_STREAM_INFO_H__
+
+#include <gst/gst.h>
+
+G_BEGIN_DECLS
+
+typedef struct _GstPlayerAudioStreamInfo GstPlayerAudioStreamInfo;
+
+GType                gst_player_audio_stream_info_get_type           (void);
+#define GST_PLAYER_TYPE_AUDIO_STREAM_INFO  (gst_player_audio_stream_info_get_type())
+#define GST_IS_PLAYER_TYPE_AUDIO_STREAM_INFO(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GST_PLAYER_TYPE_AUDIO_STREAM_INFO))
+
+GstPlayerAudioStreamInfo * gst_player_audio_stream_info_new         (gint index, GstTagList * tags);
+void                       gst_player_audio_stream_info_free        (GstPlayerAudioStreamInfo * audioinfo);
+GstPlayerAudioStreamInfo * gst_player_audio_stream_info_copy        (GstPlayerAudioStreamInfo * audioinfo);
+gint                       gst_player_audio_stream_info_get_index   (GstPlayerAudioStreamInfo * audioinfo);
+gboolean                   gst_player_audio_stream_info_get_title   (GstPlayerAudioStreamInfo * audioinfo,
+                                                                     gchar ** val);
+gboolean                   gst_player_audio_stream_info_get_lang_code (GstPlayerAudioStreamInfo * audioinfo,
+                                                                       gchar ** val);
+G_END_DECLS
+
+#endif /* __GST_PLAYER_AUDIO_STREAM_INFO_H__ */

--- a/lib/gst/player/gstplayer-media-info.c
+++ b/lib/gst/player/gstplayer-media-info.c
@@ -1,0 +1,142 @@
+/* GStreamer
+ *
+ * Copyright (C) 2014 Sebastian Dröge <sebastian@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstplayer-media-info.h"
+#include "gstplayer-audio-stream-info.h"
+#include "gstplayer-video-stream-info.h"
+#include "gstplayer-text-stream-info.h"
+
+G_DEFINE_BOXED_TYPE (GstPlayerMediaInfo, gst_player_media_info,
+    gst_player_media_info_copy, gst_player_media_info_free);
+
+GstPlayerMediaInfo *
+gst_player_media_info_new (GstPlayerMediaType type, const gchar * uri)
+{
+  GstPlayerMediaInfo *info = NULL;
+
+  info = g_slice_new0 (GstPlayerMediaInfo);
+  info->type = type;
+  info->uri = uri ? g_strdup (uri) : NULL;
+
+  if (type == GST_PLAYER_MEDIA_TYPE_AUDIO)
+          info->array = g_ptr_array_new_with_free_func
+                  ((GDestroyNotify)gst_player_audio_stream_info_free);
+  else if (type == GST_PLAYER_MEDIA_TYPE_VIDEO)
+          info->array = g_ptr_array_new_with_free_func
+                  ((GDestroyNotify)gst_player_video_stream_info_free);
+  else if (type == GST_PLAYER_MEDIA_TYPE_TEXT)
+          info->array = g_ptr_array_new_with_free_func
+                  ((GDestroyNotify)gst_player_text_stream_info_free);
+
+  return info;
+}
+
+void
+gst_player_media_info_free (GstPlayerMediaInfo * info)
+{
+  if (info->uri)
+    g_free (info->uri);
+
+  if (info->array)
+    g_ptr_array_free (info->array, TRUE);
+
+  if (info->tags)
+    gst_tag_list_unref (info->tags);
+
+  g_slice_free (GstPlayerMediaInfo, info);
+}
+
+static void
+copy_array (gpointer data, gpointer user_data)
+{
+  g_ptr_array_add (user_data, data);
+}
+
+GstPlayerMediaInfo *
+gst_player_media_info_copy (GstPlayerMediaInfo * info)
+{
+  GstPlayerMediaInfo *ret = NULL;
+
+  g_return_val_if_fail ((info != NULL), NULL);
+
+  ret = gst_player_media_info_new (info->type, info->uri);
+
+  if (info->tags)
+    ret->tags = gst_tag_list_copy (info->tags);
+
+  ret->total = info->total;
+  ret->current = info->current;
+
+  g_ptr_array_foreach (info->array, copy_array, ret->array);
+
+  return ret;
+}
+
+void
+gst_player_media_info_append (GstPlayerMediaInfo * info, gpointer data)
+{
+  g_return_if_fail (info != NULL);
+
+  g_ptr_array_add (info->array, data);
+}
+
+struct _GstPlayerMediaInfoIter {
+  GstPlayerMediaInfo *info;
+  int index;
+};
+
+void
+gst_player_media_info_iter_init (GstPlayerMediaInfoIter * iter,
+                                 GstPlayerMediaInfo * info)
+{
+  GstPlayerMediaInfoIter *i = iter;
+
+  i->info = info;
+  i->index = 0;
+}
+
+gboolean
+gst_player_media_info_iter_next (GstPlayerMediaInfoIter * iter,
+                                 const gpointer **data)
+{
+  GstPlayerMediaInfoIter *i = iter;
+
+  if (i->index >= i->info->array->len)
+    return FALSE;
+
+  *data = i->info->array->pdata[i->index];
+  i->index++;
+
+  return TRUE;
+}
+
+void
+gst_player_media_info_foreach (GstPlayerMediaInfo * info,
+                               GstPlayerMediaInfoForEachFunc func,
+                               gpointer user_data)
+{
+  int i;
+
+  g_return_if_fail (info != NULL);
+
+  for (i = 0; i < info->array->len; i++) {
+    func (info->array->pdata[i], user_data);
+  }
+}

--- a/lib/gst/player/gstplayer-media-info.h
+++ b/lib/gst/player/gstplayer-media-info.h
@@ -1,0 +1,76 @@
+/* GStreamer
+ *
+ * Copyright (C) 2014 Sebastian Dröge <sebastian@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_PLAYER_MEDIA_INFO_H__
+#define __GST_PLAYER_MEDIA_INFO_H__
+
+#include <gst/gst.h>
+
+#include "gstplayer-audio-stream-info.h"
+#include "gstplayer-video-stream-info.h"
+#include "gstplayer-text-stream-info.h"
+
+G_BEGIN_DECLS
+
+typedef enum
+{
+  GST_PLAYER_MEDIA_TYPE_AUDIO,
+  GST_PLAYER_MEDIA_TYPE_VIDEO,
+  GST_PLAYER_MEDIA_TYPE_TEXT,
+} GstPlayerMediaType;
+
+typedef struct _GstPlayerMediaInfo GstPlayerMediaInfo;
+typedef struct _GstPlayerMediaInfoIter GstPlayerMediaInfoIter;
+
+struct _GstPlayerMediaInfo
+{
+  GPtrArray *array;
+  GstPlayerMediaType type;
+
+  GstTagList *tags;
+
+  gchar *uri;
+  gint total;
+  gint current;
+};
+
+
+GType                gst_player_media_info_get_type           (void);
+#define GST_PLAYER_TYPE_MEDIA_INFO  (gst_player_media_info_get_type())
+
+typedef void       (*GstPlayerMediaInfoForEachFunc) (gpointer * streaminfo,
+                                                     gpointer user_data);
+
+GstPlayerMediaInfo * gst_player_media_info_new      (GstPlayerMediaType type,
+                                                     const gchar * uri);
+void                 gst_player_media_info_free     (GstPlayerMediaInfo * info);
+GstPlayerMediaInfo * gst_player_media_info_copy     (GstPlayerMediaInfo * info);
+void                 gst_player_media_info_append   (GstPlayerMediaInfo *info,
+                                                     gpointer data);
+void                 gst_player_media_info_iter_init (GstPlayerMediaInfoIter * iter,
+                                                      GstPlayerMediaInfo * info);
+gboolean             gst_player_media_info_iter_next (GstPlayerMediaInfoIter * iter,
+                                                      const gpointer **data);
+void                 gst_player_media_info_foreach  (GstPlayerMediaInfo * info,
+                                                     GstPlayerMediaInfoForEachFunc func,
+                                                     gpointer user_data);
+G_END_DECLS
+
+#endif /* __GST_PLAYER_MEDIA_INFO_H__ */

--- a/lib/gst/player/gstplayer-text-stream-info.c
+++ b/lib/gst/player/gstplayer-text-stream-info.c
@@ -1,0 +1,70 @@
+/* GStreamer
+ *
+ * Copyright (C) 2014 Sebastian Dröge <sebastian@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstplayer-text-stream-info.h"
+
+struct _GstPlayerTextStreamInfo
+{
+  gint index;
+  GstTagList *tags;
+};
+
+G_DEFINE_BOXED_TYPE (GstPlayerTextStreamInfo, gst_player_text_stream_info,
+    gst_player_text_stream_info_copy, gst_player_text_stream_info_free);
+
+GstPlayerTextStreamInfo *
+gst_player_text_stream_info_new (gint index, GstTagList * tags)
+{
+  GstPlayerTextStreamInfo *info = NULL;
+
+  info  = g_slice_new0 (GstPlayerTextStreamInfo);
+  info->index = index;
+  info->tags = tags;
+
+  return info;
+}
+
+void
+gst_player_text_stream_info_free (GstPlayerTextStreamInfo * textinfo)
+{
+  textinfo->index = -1;
+  gst_tag_list_unref (textinfo->tags);
+  g_slice_free (GstPlayerTextStreamInfo, textinfo);
+}
+
+GstPlayerTextStreamInfo *
+gst_player_text_stream_info_copy (GstPlayerTextStreamInfo * textinfo)
+{
+  GstPlayerTextStreamInfo *info = NULL;
+
+  g_return_val_if_fail (textinfo != NULL, NULL);
+
+  info = gst_player_text_stream_info_new (textinfo->index, textinfo->tags);
+
+  return info;
+}
+
+gint
+gst_player_text_stream_info_get_index (GstPlayerTextStreamInfo * textinfo)
+{
+  g_return_val_if_fail (textinfo != NULL, -1);
+
+  return textinfo->index;
+}

--- a/lib/gst/player/gstplayer-text-stream-info.h
+++ b/lib/gst/player/gstplayer-text-stream-info.h
@@ -18,10 +18,23 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __PLAYER_H__
-#define __PLAYER_H__
+#ifndef __GST_PLAYER_TEXT_STREAM_INFO_H__
+#define __GST_PLAYER_TEXT_STREAM_INFO_H__
 
-#include <gst/player/gstplayer.h>
-#include <gst/player/gstplayer-media-info.h>
+#include <gst/gst.h>
 
-#endif /* __PLAYER_H__ */
+G_BEGIN_DECLS
+
+typedef struct _GstPlayerTextStreamInfo GstPlayerTextStreamInfo;
+
+GType                gst_player_text_stream_info_get_type           (void);
+#define GST_PLAYER_TYPE_TEXT_STREAM_INFO  (gst_player_text_stream_info_get_type())
+
+GstPlayerTextStreamInfo * gst_player_text_stream_info_new         (gint index, GstTagList * tags);
+void                      gst_player_text_stream_info_free        (GstPlayerTextStreamInfo * textinfo);
+GstPlayerTextStreamInfo * gst_player_text_stream_info_copy        (GstPlayerTextStreamInfo * textinfo);
+gint                      gst_player_text_stream_info_get_index   (GstPlayerTextStreamInfo * textinfo);
+
+G_END_DECLS
+
+#endif /* __GST_PLAYER_TEXT_STREAM_INFO_H__ */

--- a/lib/gst/player/gstplayer-video-stream-info.c
+++ b/lib/gst/player/gstplayer-video-stream-info.c
@@ -1,0 +1,70 @@
+/* GStreamer
+ *
+ * Copyright (C) 2014 Sebastian Dröge <sebastian@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstplayer-video-stream-info.h"
+
+struct _GstPlayerVideoStreamInfo
+{
+  gint index;
+  GstTagList *tags;
+};
+
+G_DEFINE_BOXED_TYPE (GstPlayerVideoStreamInfo, gst_player_video_stream_info,
+    gst_player_video_stream_info_copy, gst_player_video_stream_info_free);
+
+GstPlayerVideoStreamInfo *
+gst_player_video_stream_info_new (gint index, GstTagList * tags)
+{
+  GstPlayerVideoStreamInfo *info = NULL;
+
+  info  = g_slice_new0 (GstPlayerVideoStreamInfo);
+  info->index = index;
+  info->tags = tags;
+
+  return info;
+}
+
+void
+gst_player_video_stream_info_free (GstPlayerVideoStreamInfo * videoinfo)
+{
+  videoinfo->index = -1;
+  gst_tag_list_unref (videoinfo->tags);
+  g_slice_free (GstPlayerVideoStreamInfo, videoinfo);
+}
+
+GstPlayerVideoStreamInfo *
+gst_player_video_stream_info_copy (GstPlayerVideoStreamInfo * videoinfo)
+{
+  GstPlayerVideoStreamInfo *info = NULL;
+
+  g_return_val_if_fail (videoinfo != NULL, NULL);
+
+  info = gst_player_video_stream_info_new (videoinfo->index, videoinfo->tags);
+
+  return info;
+}
+
+gint
+gst_player_video_stream_info_get_index (GstPlayerVideoStreamInfo * videoinfo)
+{
+  g_return_val_if_fail (videoinfo != NULL, -1);
+
+  return videoinfo->index;
+}

--- a/lib/gst/player/gstplayer-video-stream-info.h
+++ b/lib/gst/player/gstplayer-video-stream-info.h
@@ -1,0 +1,39 @@
+/* GStreamer
+ *
+ * Copyright (C) 2014 Sebastian Dröge <sebastian@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_PLAYER_VIDEO_STREAM_INFO_H__
+#define __GST_PLAYER_VIDEO_STREAM_INFO_H__
+
+#include <gst/gst.h>
+
+G_BEGIN_DECLS
+
+typedef struct _GstPlayerVideoStreamInfo GstPlayerVideoStreamInfo;
+
+GType                gst_player_video_stream_info_get_type           (void);
+#define GST_PLAYER_TYPE_VIDEO_STREAM_INFO  (gst_player_video_stream_info_get_type())
+
+GstPlayerVideoStreamInfo * gst_player_video_stream_info_new         (gint index, GstTagList * tags);
+void                       gst_player_video_stream_info_free        (GstPlayerVideoStreamInfo * videoinfo);
+GstPlayerVideoStreamInfo * gst_player_video_stream_info_copy        (GstPlayerVideoStreamInfo * videoinfo);
+gint                       gst_player_video_stream_info_get_index   (GstPlayerVideoStreamInfo * videoinfo);
+G_END_DECLS
+
+#endif /* __GST_PLAYER_VIDEO_STREAM_INFO_H__ */

--- a/lib/gst/player/gstplayer.h
+++ b/lib/gst/player/gstplayer.h
@@ -85,6 +85,12 @@ gpointer     gst_player_get_window_handle             (GstPlayer    * player);
 void         gst_player_set_window_handle             (GstPlayer    * player,
                                                        gpointer       val);
 
+gboolean     gst_player_select_audio_stream           (GstPlayer    * player,
+                                                       gint           streamid);
+gboolean     gst_player_select_video_stream           (GstPlayer    * player,
+                                                       gint           streamid);
+gboolean     gst_player_select_text_stream            (GstPlayer    * player,
+                                                       gint           streamid);
 
 GQuark       gst_player_error_quark                   (void);
 #define      GST_PLAYER_ERROR                         gst_player_error_quark ()


### PR DESCRIPTION
This patch adds support to retrieve media information for
audio/video/text streams.

Tags from each individual stream for Audio. Video and Text
 are parsed and stored in the appropriate structure 
(GstPlayerAudioStreamInfo, GstPlayerVideoStreamInfo, and
 GstPlayerTextStreamInfo respectively).

The primary structure is GstPlayerMediaInfo. An instance of
 this structure for each stream type is in GstPlayer.

Once the data is parsed from each of these streams, data
 is passed to the client via the signals 
(AUDIO_DATA_UPDATED, VIDEO_DATA_UPDATED,
 TEXT_DATA_UPDATED).


