### PR TITLE
Add a 'missing-plugin' signal to player

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_SUBST(LT_AGE)
 PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES(GLIB, [glib-2.0 gobject-2.0])
-PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 >= 1.4 gstreamer-video-1.0 >= 1.4])
+PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 >= 1.4 gstreamer-video-1.0 >= 1.4 gstreamer-pbutils-1.0])
 
 GLIB_PREFIX="`$PKG_CONFIG --variable=prefix glib-2.0`"
 AC_SUBST(GLIB_PREFIX)

--- a/lib/gst/player/gstplayer.h
+++ b/lib/gst/player/gstplayer.h
@@ -44,7 +44,8 @@ GType        gst_player_error_get_type                (void);
 #define      GST_TYPE_PLAYER_ERROR                    (gst_player_error_get_type ())
 
 typedef enum {
-  GST_PLAYER_ERROR_FAILED = 0
+  GST_PLAYER_ERROR_FAILED = 0,
+  GST_PLAYER_ERROR_MISSING_PLUGIN
 } GstPlayerError;
 
 const gchar *gst_player_error_get_name                (GstPlayerError error);


### PR DESCRIPTION
Also use the signal to notify user in both gst-play and gtk-play.

For gtk-play this means a GtkInfoBar that says e.g. `Missing plugin 'H.264 decoder'.` For gst-play it's just a g_warning() with same content.