### PR TITLE
mediainfo-v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_SUBST(LT_AGE)
 PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES(GLIB, [glib-2.0 gobject-2.0])
-PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 >= 1.4 gstreamer-video-1.0 >= 1.4])
+PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 >= 1.4 gstreamer-video-1.0 >= 1.4 gstreamer-tag-1.0 >= 1.4])
 
 GLIB_PREFIX="`$PKG_CONFIG --variable=prefix glib-2.0`"
 AC_SUBST(GLIB_PREFIX)

--- a/gst-play/gst-play.c
+++ b/gst-play/gst-play.c
@@ -45,6 +45,7 @@ typedef struct
   GstPlayer *player;
   GstState desired_state;
 
+  GstPlayerMediaInfo  *media_info;
   GMainLoop *loop;
 } GstPlay;
 
@@ -110,6 +111,210 @@ buffering_cb (GstPlayer * player, gint percent, GstPlay * play)
   g_print ("Buffering: %d\n", percent);
 }
 
+static void
+print_one_tag (const GstTagList *list, const gchar *tag, gpointer user_data)
+{
+  gint i, num;
+
+  num = gst_tag_list_get_tag_size (list, tag);
+  for (i = 0; i < num; ++i) {
+    const GValue *val;
+
+    val = gst_tag_list_get_value_index (list, tag, i);
+    if (G_VALUE_HOLDS_STRING (val)) {
+      g_print ("    %s : %s \n", tag, g_value_get_string (val));
+    }
+    else if (G_VALUE_HOLDS_UINT (val)) {
+      g_print ("    %s : %u \n", tag, g_value_get_uint (val));
+    }
+    else if (G_VALUE_HOLDS_DOUBLE (val)) {
+      g_print ("    %s : %g \n", tag, g_value_get_double (val));
+    }
+    else if (G_VALUE_HOLDS_BOOLEAN (val)) {
+      g_print ("    %s : %s \n", tag,
+                g_value_get_boolean (val) ? "true" : "false");
+    }
+    else if (GST_VALUE_HOLDS_DATE_TIME (val)) {
+      GstDateTime *dt = g_value_get_boxed (val);
+      gchar *dt_str = gst_date_time_to_iso8601_string (dt);
+
+      g_print ("    %s : %s \n", tag, dt_str);
+      g_free (dt_str);
+    }
+    else {
+      g_print ("    %s : tag of type '%s' \n", tag, G_VALUE_TYPE_NAME (val));
+    }
+  }
+}
+
+static void
+print_video_info (GstPlayerVideoInfo *info)
+{
+  guint num, denom;
+
+  if (info == NULL)
+    return;
+
+  g_print ("  width : %u\n", gst_player_video_info_get_width(info));
+  g_print ("  height : %d\n", gst_player_video_info_get_height (info));
+  g_print ("  max_bitrate : %u\n", gst_player_video_info_get_max_bitrate (info));
+  g_print ("  bitrate : %u\n", gst_player_video_info_get_bitrate (info));
+  gst_player_video_info_get_framerate (info, &num, &denom);
+  g_print ("  frameate : %.2f\n", (gdouble) num/denom);
+  gst_player_video_info_get_pixel_aspect_ratio (info, &num, &denom);
+  g_print ("  pixel-aspect-ratio : %u x %u\n", num, denom);
+}
+
+static void
+print_audio_info (GstPlayerAudioInfo *info)
+{
+  if (info == NULL)
+    return;
+
+  g_print ("  sample rate : %u\n", gst_player_audio_info_get_sample_rate (info));
+  g_print ("  channels : %u\n", gst_player_audio_info_get_channels (info));
+  g_print ("  max_bitrate : %u\n", gst_player_audio_info_get_max_bitrate (info));
+  g_print ("  bitrate : %u\n", gst_player_audio_info_get_bitrate (info));
+  g_print ("  language : %s\n", gst_player_audio_info_get_language (info));
+}
+
+static void
+print_subtitle_info (GstPlayerSubtitleInfo *info)
+{
+  if (info == NULL)
+    return;
+
+  g_print ("  language : %s\n", gst_player_subtitle_get_language (info));
+}
+
+static void
+print_all_stream_info (GstPlay *play)
+{
+  guint count = 0;
+  GList *l, *list;
+  GstPlayerMediaInfo  *info = play->media_info;
+
+  if (!play->media_info)
+    return;
+
+  list = gst_player_media_info_get_stream_list (info);
+  g_print ("URI : %s\n", gst_player_media_info_get_uri (info));
+  g_print ("Duration: %" GST_TIME_FORMAT "\n",
+      GST_TIME_ARGS(gst_player_media_info_get_duration (info)));
+  for (l = list; l != NULL; l = l->next) {
+    GstTagList  *tags = NULL;
+    GstPlayerStreamInfo *stream = (GstPlayerStreamInfo*) l->data;
+
+    g_print (" Stream # %u \n", count++);
+    g_print ("  type : %s_%u\n",
+              gst_player_stream_info_get_stream_type_nick (stream),
+              gst_player_stream_info_get_stream_index (stream));
+    tags = gst_player_stream_info_get_stream_tags (stream);
+    g_print ("  taglist : \n");
+    if (tags) {
+      gst_tag_list_foreach (tags, print_one_tag, NULL);
+    }
+
+    if (GST_IS_PLAYER_VIDEO_INFO (stream))
+      print_video_info ((GstPlayerVideoInfo*)stream);
+    if (GST_IS_PLAYER_AUDIO_INFO (stream))
+      print_audio_info ((GstPlayerAudioInfo*)stream);
+    if (GST_IS_PLAYER_SUBTITLE_INFO (stream))
+      print_subtitle_info ((GstPlayerSubtitleInfo*)stream);
+  }
+
+  gst_player_stream_info_list_free (list);
+}
+
+static void
+print_all_video_stream (GstPlay *play)
+{
+  GList *list = NULL, *l;
+
+  if (!play->media_info)
+    return;
+
+  list = gst_player_get_video_streams (play->media_info);
+  if (!list)
+    return;
+
+  g_print ("All video streams\n");
+  for (l = list; l != NULL; l = l->next) {
+    GstPlayerVideoInfo  *info = (GstPlayerVideoInfo*) l->data;
+    GstPlayerStreamInfo *sinfo = (GstPlayerStreamInfo*) info;
+    g_print (" %s_%d #\n", gst_player_stream_info_get_stream_type_nick (sinfo),
+            gst_player_stream_info_get_stream_index (sinfo));
+    print_video_info (info);
+  }
+  gst_player_stream_info_list_free (list);
+}
+
+static void
+print_all_subtitle_stream (GstPlay *play)
+{
+  GList *list = NULL, *l;
+
+  if (!play->media_info)
+    return;
+
+  list = gst_player_get_subtitle_streams (play->media_info);
+
+  if (!list)
+  return;
+
+  g_print ("All subtitle streams:\n");
+  for (l = list; l != NULL; l = l->next) {
+    GstPlayerSubtitleInfo  *info = (GstPlayerSubtitleInfo*) l->data;
+    GstPlayerStreamInfo *sinfo = (GstPlayerStreamInfo*) info;
+    g_print (" %s_%d #\n", gst_player_stream_info_get_stream_type_nick (sinfo),
+    gst_player_stream_info_get_stream_index (sinfo));
+    print_subtitle_info (info);
+  }
+
+  gst_player_stream_info_list_free (list);
+}
+
+static void
+print_all_audio_stream (GstPlay *play)
+{
+  GList *list = NULL, *l;
+
+  if (!play->media_info)
+    return;
+
+  list = gst_player_get_audio_streams (play->media_info);
+  if (!list)
+    return;
+
+  g_print ("All audio streams: \n");
+  for (l = list; l != NULL; l = l->next) {
+    GstPlayerAudioInfo  *info = (GstPlayerAudioInfo*) l->data;
+    GstPlayerStreamInfo *sinfo = (GstPlayerStreamInfo*) info;
+    g_print (" %s_%d #\n", gst_player_stream_info_get_stream_type_nick (sinfo),
+              gst_player_stream_info_get_stream_index (sinfo));
+    print_audio_info (info);
+  }
+
+  gst_player_stream_info_list_free (list);
+}
+
+static void
+print_current_tracks (GstPlay *play)
+{
+  g_print ("Current video track: \n");
+  print_video_info (gst_player_get_video_track(play->player));
+  g_print ("Current audio track: \n");
+  print_audio_info (gst_player_get_audio_track(play->player));
+  g_print ("Current subtitle track: \n");
+  print_subtitle_info (gst_player_get_subtitle_track(play->player));
+}
+
+static void
+media_info_cb (GstPlayer *player, GstPlayerMediaInfo *info, GstPlay *play)
+{
+  play->media_info = info;
+}
+
 static GstPlay *
 play_new (gchar ** uris, gdouble initial_volume)
 {
@@ -133,6 +338,9 @@ play_new (gchar ** uris, gdouble initial_volume)
   g_signal_connect (play->player, "end-of-stream",
       G_CALLBACK (end_of_stream_cb), play);
   g_signal_connect (play->player, "error", G_CALLBACK (error_cb), play);
+
+  g_signal_connect (play->player, "media-info-updated",
+      G_CALLBACK (media_info_cb), play);
 
   play->loop = g_main_loop_new (NULL, FALSE);
   play->desired_state = GST_STATE_PLAYING;
@@ -347,6 +555,18 @@ keyboard_cb (const gchar * key_input, gpointer user_data)
   GstPlay *play = (GstPlay *) user_data;
 
   switch (g_ascii_tolower (key_input[0])) {
+    case 'i':
+      print_all_stream_info (play);
+      g_print ("\n");
+      print_all_video_stream (play);
+      g_print ("\n");
+      print_all_audio_stream (play);
+      g_print ("\n");
+      print_all_subtitle_stream (play);
+      g_print ("\n");
+      print_current_tracks (play);
+      g_print ("\n");
+      break;
     case ' ':
       toggle_paused (play);
       break;

--- a/lib/gst/player/Makefile.am
+++ b/lib/gst/player/Makefile.am
@@ -1,7 +1,8 @@
 lib_LTLIBRARIES = libgstplayer-@GST_PLAYER_API_VERSION@.la
 
 libgstplayer_@GST_PLAYER_API_VERSION@_la_SOURCES = \
-	gstplayer.c
+	gstplayer.c  \
+	gstplayer-media-info.c
 
 libgstplayer_@GST_PLAYER_API_VERSION@_la_CFLAGS = \
 	-I$(top_srcdir)/lib \
@@ -22,9 +23,12 @@ libgstplayer_@GST_PLAYER_API_VERSION@_la_LIBADD = \
 
 libgstplayerdir = $(includedir)/gst-player-@GST_PLAYER_API_VERSION@/gst/player
 
+noinst_HEADERS = gstplayer-media-info-private.h
+
 libgstplayer_HEADERS = \
 	player.h \
-	gstplayer.h
+	gstplayer.h \
+	gstplayer-media-info.h
 
 CLEANFILES =
 
@@ -51,6 +55,7 @@ GstPlayer-@GST_PLAYER_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstplayer-@G
 		--libtool="${LIBTOOL}" \
 		--pkg gobject-2.0 \
 		--pkg gstreamer-1.0 \
+		--pkg gstreamer-tag-1.0 \
 		--pkg-export gstreamer-player-@GST_PLAYER_API_VERSION@ \
 		--add-init-section="gst_init(NULL,NULL);" \
 		--output $@ \

--- a/lib/gst/player/gstplayer-media-info-private.h
+++ b/lib/gst/player/gstplayer-media-info-private.h
@@ -1,0 +1,81 @@
+/* GStreamer
+ * Copyright (C) 2015 Brijesh Singh <brijesh.ksingh@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstplayer-media-info.h"
+
+struct _GstPlayerStreamInfo
+{
+  GObject parent;
+
+  GstCaps *caps;
+  gint stream_index;
+  GstTagList  *tags;
+};
+
+struct _GstPlayerSubtitleInfo
+{
+  GstPlayerStreamInfo  parent;
+
+  gchar *language;
+};
+
+struct _GstPlayerAudioInfo
+{
+  GstPlayerStreamInfo  parent;
+
+  guint channels;
+  guint sample_rate;
+  guint depth;
+
+  guint bitrate;
+  guint max_bitrate;
+
+  gchar *language;
+};
+
+struct _GstPlayerVideoInfo
+{
+  GstPlayerStreamInfo  parent;
+
+  guint width;
+  guint height;
+  guint framerate_num;
+  guint framerate_denom;
+  guint par_num;
+  guint par_denom;
+
+  guint bitrate;
+  guint max_bitrate;
+};
+
+struct _GstPlayerMediaInfo
+{
+  GObject parent;
+
+  gchar *uri;
+  GList *stream_list;
+
+  GstClockTime  duration;
+};
+
+GstPlayerStreamInfo*    gst_player_stream_info_new (GstPlayerStreamInfo *ref);
+GstPlayerVideoInfo*     gst_player_video_info_new (GstPlayerVideoInfo *ref);
+GstPlayerAudioInfo*     gst_player_audio_info_new (GstPlayerAudioInfo *ref);
+GstPlayerSubtitleInfo*  gst_player_subtitle_info_new (GstPlayerSubtitleInfo *ref);
+

--- a/lib/gst/player/gstplayer-media-info.c
+++ b/lib/gst/player/gstplayer-media-info.c
@@ -1,0 +1,603 @@
+#include "gstplayer-media-info.h"
+#include "gstplayer-media-info-private.h"
+
+/* Per-stream information */
+G_DEFINE_TYPE (GstPlayerStreamInfo, gst_player_stream_info, G_TYPE_OBJECT);
+
+static void
+gst_player_stream_info_init (GstPlayerStreamInfo * sinfo)
+{
+  sinfo->caps = NULL;
+  sinfo->tags = NULL;
+  sinfo->stream_index = -1;
+}
+
+static void
+gst_player_stream_info_finalize (GObject * object)
+{
+  GstPlayerStreamInfo *sinfo = GST_PLAYER_STREAM_INFO (object);
+
+  if (sinfo->caps) {
+    gst_caps_unref (sinfo->caps);
+    sinfo->caps = NULL;
+  }
+
+  if (sinfo->tags) {
+    gst_tag_list_unref (sinfo->tags);
+    sinfo->tags = NULL;
+  }
+
+  G_OBJECT_CLASS (gst_player_stream_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_stream_info_class_init (GObjectClass * klass)
+{
+  klass->finalize = gst_player_stream_info_finalize;
+}
+
+GstPlayerStreamInfo*
+gst_player_stream_info_new (GstPlayerStreamInfo *ref)
+{
+  GstPlayerStreamInfo *ret = NULL;
+
+  if (GST_IS_PLAYER_VIDEO_INFO (ref))
+    ret = (GstPlayerStreamInfo*) gst_player_video_info_new
+                                    ((GstPlayerVideoInfo*)ref);
+  if (GST_IS_PLAYER_AUDIO_INFO (ref))
+    ret = (GstPlayerStreamInfo*) gst_player_audio_info_new
+                                    ((GstPlayerAudioInfo*)ref);
+  if (GST_IS_PLAYER_SUBTITLE_INFO (ref))
+    ret = (GstPlayerStreamInfo*) gst_player_subtitle_info_new
+                                    ((GstPlayerSubtitleInfo*)ref);
+
+  ret->stream_index = gst_player_stream_info_get_stream_index (ref);
+  ret->tags = gst_player_stream_info_get_stream_tags (ref);
+  ret->caps = gst_player_stream_info_get_stream_caps (ref);
+
+  return ret;
+}
+
+/**
+ * gst_player_stream_info_get_stream_index:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: the stream index of this stream.
+ */
+gint
+gst_player_stream_info_get_stream_index (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), NULL);
+
+  return info->stream_index;
+}
+
+/**
+ * gst_player_stream_info_get_stream_type_nick:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: a human readable name for the stream type of the given @info (ex : "audio",
+ * "video",...).
+ */
+const gchar*
+gst_player_stream_info_get_stream_type_nick (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), NULL);
+
+  if (GST_IS_PLAYER_VIDEO_INFO (info))
+    return "video";
+
+  if (GST_IS_PLAYER_AUDIO_INFO (info))
+    return "audio";
+
+  if (GST_IS_PLAYER_SUBTITLE_INFO (info))
+    return "subtitle";
+
+  return NULL;
+}
+
+/**
+ * gst_player_stream_info_get_tags:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: (transfer full): the tags contained in this stream.
+ */
+GstTagList*
+gst_player_stream_info_get_stream_tags (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), NULL);
+
+  return info->tags;
+}
+
+/**
+ * gst_player_stream_info_get_caps:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: (transfer full): the #GstCaps of the stream.
+ */
+GstCaps*
+gst_player_stream_info_get_stream_caps (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), NULL);
+
+  return info->caps;
+}
+
+/* Video information */
+G_DEFINE_TYPE (GstPlayerVideoInfo, gst_player_video_info,
+    GST_TYPE_PLAYER_STREAM_INFO);
+
+static void
+gst_player_video_info_init (GstPlayerVideoInfo * info)
+{
+  /* Nothing to do here */
+}
+
+static void
+gst_player_video_info_finalize (GObject * gobject)
+{
+  G_OBJECT_CLASS (gst_player_video_info_parent_class)->finalize (gobject);
+}
+
+static void
+gst_player_video_info_class_init (GObjectClass * klass)
+{
+  klass->finalize = gst_player_video_info_finalize;
+}
+
+GstPlayerVideoInfo*
+gst_player_video_info_new (GstPlayerVideoInfo *ref)
+{
+  GstPlayerVideoInfo *ret = NULL;
+
+  ret = g_object_new (GST_TYPE_PLAYER_VIDEO_INFO, NULL);
+
+  if (ref) {
+    ret->width = ref->width;
+    ret->height  = ref->height;
+    ret->framerate_num = ref->framerate_num;
+    ret->framerate_denom = ref->framerate_denom;
+    ret->par_num = ref->par_num;
+    ret->par_denom = ref->par_denom;
+    ret->bitrate = ref->bitrate;
+    ret->max_bitrate = ref->max_bitrate;
+  }
+
+  return ret;
+}
+
+/**
+ * gst_player_video_info_get_width:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the width of video in #GstPlayerVideoInfo.
+ */
+guint
+gst_player_video_info_get_width (const GstPlayerVideoInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->width;
+}
+
+/**
+ * gst_player_video_info_get_height:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the height of video in #GstPlayerVideoInfo.
+ */
+guint
+gst_player_video_info_get_height (const GstPlayerVideoInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->height;
+}
+
+/**
+ * gst_player_video_info_get_framerate_num:
+ * @info: a #GstPlayerVideoInfo
+ *
+ */
+void
+gst_player_video_info_get_framerate (const GstPlayerVideoInfo *info,
+  guint *fps_n, guint *fps_d)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), NULL);
+
+  *fps_n = info->framerate_num;
+  *fps_d = info->framerate_denom;
+}
+
+/**
+ * gst_player_video_info_get_pixel_aspect_ratio:
+ * @info: a #GstPlayerVideoInfo
+ *
+ */
+void
+gst_player_video_info_get_pixel_aspect_ratio (const GstPlayerVideoInfo *info,
+  guint *par_d, guint *par_n)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), NULL);
+
+  *par_n = info->par_num;
+  *par_d = info->par_denom;
+}
+
+/**
+ * gst_player_video_info_get_bitrate:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the current bitrate of video in #GstPlayerVideoInfo.
+ */
+guint
+gst_player_video_info_get_bitrate (const GstPlayerVideoInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->bitrate;
+}
+
+/**
+ * gst_player_video_info_get_max_bitrate:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the maximum bitrate of video in #GstPlayerVideoInfo.
+ */
+guint
+gst_player_video_info_get_max_bitrate (const GstPlayerVideoInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->max_bitrate;
+}
+
+/* Audio information */
+G_DEFINE_TYPE (GstPlayerAudioInfo, gst_player_audio_info,
+    GST_TYPE_PLAYER_STREAM_INFO);
+
+static void
+gst_player_audio_info_init (GstPlayerAudioInfo * info)
+{
+  info->language = NULL;
+}
+
+static void
+gst_player_audio_info_finalize (GObject * object)
+{
+  GstPlayerAudioInfo *info = GST_PLAYER_AUDIO_INFO (object);
+
+  g_free (info->language);
+  info->language = NULL;
+
+  G_OBJECT_CLASS (gst_player_audio_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_audio_info_class_init (GObjectClass * klass)
+{
+  klass->finalize = gst_player_audio_info_finalize;
+}
+
+GstPlayerAudioInfo*
+gst_player_audio_info_new (GstPlayerAudioInfo *ref)
+{
+  GstPlayerAudioInfo *ret = NULL;
+
+  ret = g_object_new (GST_TYPE_PLAYER_AUDIO_INFO, NULL);
+
+  if (ref) {
+    ret->sample_rate = ref->sample_rate;
+    ret->language = g_strdup (ref->language);
+    ret->channels = ref->channels;
+    ret->bitrate = ref->bitrate;
+    ret->max_bitrate = ref->max_bitrate;
+  }
+
+  return ret;
+}
+
+/**
+ * gst_player_audio_info_get_language:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the language of the stream, or NULL if unknown.
+ */
+gchar*
+gst_player_audio_info_get_language(const GstPlayerAudioInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), NULL);
+
+ return info->language;
+}
+
+/**
+ * gst_player_audio_info_get_channels:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the number of audio channels in #GstPlayerAudioInfo.
+ */
+guint
+gst_player_audio_info_get_channels (const GstPlayerAudioInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), -1);
+
+  return info->channels;
+}
+
+/**
+ * gst_player_audio_info_get_sample_rate:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the audio sample rate in #GstPlayerAudioInfo.
+ */
+guint
+gst_player_audio_info_get_sample_rate (const GstPlayerAudioInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), -1);
+
+  return info->sample_rate;
+}
+
+/**
+ * gst_player_audio_info_get_bitrate:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the audio bitrate in #GstPlayerAudioInfo.
+ */
+guint
+gst_player_audio_info_get_bitrate (const GstPlayerAudioInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), -1);
+
+  return info->bitrate;
+}
+
+/**
+ * gst_player_audio_info_get_max_bitrate:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the audio maximum bitrate in #GstPlayerAudioInfo.
+ */
+guint
+gst_player_audio_info_get_max_bitrate (const GstPlayerAudioInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), -1);
+
+  return info->max_bitrate;
+}
+
+/* Subtitle information */
+G_DEFINE_TYPE (GstPlayerSubtitleInfo, gst_player_subtitle_info,
+    GST_TYPE_PLAYER_STREAM_INFO);
+
+static void
+gst_player_subtitle_info_init (GstPlayerSubtitleInfo * info)
+{
+  info->language = NULL;
+}
+
+static void
+gst_player_subtitle_info_finalize (GObject * object)
+{
+  GstPlayerSubtitleInfo *info = GST_PLAYER_SUBTITLE_INFO (object);
+
+  g_free (info->language);
+
+  G_OBJECT_CLASS (gst_player_subtitle_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_subtitle_info_class_init (GObjectClass * klass)
+{
+  klass->finalize = gst_player_subtitle_info_finalize;
+}
+
+GstPlayerSubtitleInfo*
+gst_player_subtitle_info_new (GstPlayerSubtitleInfo *ref)
+{
+  GstPlayerSubtitleInfo *ret = NULL;
+
+  ret = g_object_new (GST_TYPE_PLAYER_SUBTITLE_INFO, NULL);
+
+  if (ref)
+    ret->language = g_strdup (ref->language);
+
+  return ret;
+}
+
+/**
+ * gst_player_subtitle_get_language:
+ * @info: a #GstPlayerSubtitleInfo
+ *
+ * Returns: the language of the stream, or NULL if unknown.
+ */
+gchar*
+gst_player_subtitle_get_language( const GstPlayerSubtitleInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_SUBTITLE_INFO (info), NULL);
+
+  return info->language;
+}
+
+/* Global media information */
+G_DEFINE_TYPE (GstPlayerMediaInfo, gst_player_media_info, G_TYPE_OBJECT);
+
+static void
+gst_player_media_info_init (GstPlayerMediaInfo * info)
+{
+  info->uri = NULL;
+  info->stream_list = NULL;
+}
+
+static void
+gst_player_media_info_finalize (GObject * object)
+{
+  GstPlayerMediaInfo  *info = GST_PLAYER_MEDIA_INFO (object);
+
+  g_free (info->uri);
+  info->uri = NULL;
+
+  if (info->stream_list) {
+    g_list_free (info->stream_list);
+    info->stream_list = NULL;
+  }
+
+  G_OBJECT_CLASS (gst_player_media_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_media_info_class_init (GstPlayerMediaInfoClass * klass)
+{
+  GObjectClass  *oclass = (GObjectClass *) klass;
+
+  oclass->finalize = gst_player_media_info_finalize;
+}
+
+/**
+ * gst_player_media_info_get_uri:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: the URI associated with #GstPlayerMediaInfo.
+ */
+gchar *
+gst_player_media_info_get_uri (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  return info->uri;
+}
+
+/**
+ * gst_player_media_info_get_stream_list:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer full) (element-type GstPlayerStreamInfo): A #GList of
+ * matching #GstPlayerStreamInfo. The caller should free it with
+ * gst_player_stream_info_list_free().
+ */
+GList *
+gst_player_media_info_get_stream_list (const GstPlayerMediaInfo *info)
+{
+  GList *list = NULL, *l;;
+
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  for (l = info->stream_list; l != NULL; l = l->next)
+    list = g_list_append (list, g_object_ref(l->data));
+
+  return list;
+}
+
+/**
+ * gst_player_get_video_streams:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer full) (element-type GstPlayerVideoInfo): A #GList of
+ * matching #GstPlayerVideoInfo. The caller should free it with
+ * gst_player_stream_info_list_free().
+ */
+GList*
+gst_player_get_video_streams (const GstPlayerMediaInfo *info)
+{
+  GList *result = NULL, *p;
+
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  for (p = info->stream_list; p != NULL; p = p->next) {
+    GstPlayerStreamInfo  *sinfo = (GstPlayerStreamInfo*) p->data;
+
+    if (GST_IS_PLAYER_VIDEO_INFO (sinfo)) {
+      GstPlayerVideoInfo  *vinfo = (GstPlayerVideoInfo*) sinfo;
+
+      result = g_list_append (result, g_object_ref(vinfo));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * gst_player_get_subtitle_streams:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer full) (element-type GstPlayerSubtitleInfo): A #GList of
+ * matching #GstPlayerSubtitleInfo. The caller should free it with
+ * gst_player_stream_info_list_free().
+ */
+GList*
+gst_player_get_subtitle_streams (const GstPlayerMediaInfo *info)
+{
+  GList *result = NULL, *p;
+
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  for (p = info->stream_list; p != NULL; p = p->next) {
+    GstPlayerStreamInfo  *sinfo = (GstPlayerStreamInfo*) p->data;
+
+    if (GST_IS_PLAYER_SUBTITLE_INFO (sinfo)) {
+      GstPlayerSubtitleInfo  *tinfo = (GstPlayerSubtitleInfo*) sinfo;
+
+      result = g_list_append (result, g_object_ref(tinfo));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * gst_player_get_audio_streams:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer full) (element-type GstPlayerAudioInfo): A #GList of
+ * matching #GstPlayerAudioInfo. The caller should free it with
+ * gst_player_stream_info_list_free().
+ */
+GList*
+gst_player_get_audio_streams (const GstPlayerMediaInfo *info)
+{
+  GList *result = NULL, *p;
+
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  for (p = info->stream_list; p != NULL; p = p->next) {
+    GstPlayerStreamInfo  *sinfo = (GstPlayerStreamInfo*) p->data;
+
+    if (GST_IS_PLAYER_AUDIO_INFO (sinfo)) {
+      GstPlayerAudioInfo  *ainfo = (GstPlayerAudioInfo*) sinfo;
+
+      result = g_list_append (result, g_object_ref(ainfo));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * gst_player_stream_info_list_free:
+ * @list: (element-type GstPlayerStreamInfo): A #GList of #GstPlayerStreamInfo
+ *
+ * frees the #GList.
+ */
+void
+gst_player_stream_info_list_free (GList *list)
+{
+  g_list_free_full (list, g_object_unref);
+}
+
+/**
+ * gst_player_media_info_get_duration:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: duration of the media.
+ */
+GstClockTime
+gst_player_media_info_get_duration (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), -1);
+
+  return info->duration;
+}
+
+

--- a/lib/gst/player/gstplayer-media-info.h
+++ b/lib/gst/player/gstplayer-media-info.h
@@ -1,0 +1,142 @@
+/* GStreamer
+ *
+ * Copyright (C) 2015 Brijesh Singh <brijesh.ksingh@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_PLAYER_MEDIA_INFO_H__
+#define __GST_PLAYER_MEDIA_INFO_H__
+
+#include <gst/gst.h>
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_PLAYER_STREAM_INFO \
+  (gst_player_stream_info_get_type ())
+#define GST_PLAYER_STREAM_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_STREAM_INFO,GstPlayerStreamInfo))
+#define GST_IS_PLAYER_STREAM_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_STREAM_INFO))
+
+typedef struct _GstPlayerStreamInfo GstPlayerStreamInfo;
+typedef GObjectClass GstPlayerStreamInfoClass;
+GType gst_player_stream_info_get_type (void);
+
+gint          gst_player_stream_info_get_stream_index
+                (const GstPlayerStreamInfo *info);
+const gchar*  gst_player_stream_info_get_stream_type_nick
+                (const GstPlayerStreamInfo *info);
+GstTagList*   gst_player_stream_info_get_stream_tags
+                (const GstPlayerStreamInfo *info);
+GstCaps*      gst_player_stream_info_get_stream_caps
+                (const GstPlayerStreamInfo *info);
+
+#define GST_TYPE_PLAYER_VIDEO_INFO \
+  (gst_player_video_info_get_type ())
+#define GST_PLAYER_VIDEO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_VIDEO_INFO, GstPlayerVideoInfo))
+#define GST_IS_PLAYER_VIDEO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_VIDEO_INFO))
+
+typedef struct _GstPlayerVideoInfo GstPlayerVideoInfo;
+typedef GObjectClass GstPlayerVideoInfoClass;
+GType gst_player_video_info_get_type (void);
+
+guint         gst_player_video_info_get_bitrate
+                (const GstPlayerVideoInfo* info);
+guint         gst_player_video_info_get_max_bitrate
+                (const GstPlayerVideoInfo* info);
+guint         gst_player_video_info_get_width
+                (const GstPlayerVideoInfo* info);
+guint         gst_player_video_info_get_height
+                (const GstPlayerVideoInfo* info);
+void          gst_player_video_info_get_framerate
+                (const GstPlayerVideoInfo* info, guint *fps_n, guint *fps_d);
+void          gst_player_video_info_get_pixel_aspect_ratio
+                (const GstPlayerVideoInfo* info, guint *par_n, guint *par_d);
+
+#define GST_TYPE_PLAYER_AUDIO_INFO \
+  (gst_player_audio_info_get_type ())
+#define GST_PLAYER_AUDIO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_AUDIO_INFO, GstPlayerAudioInfo))
+#define GST_IS_PLAYER_AUDIO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_AUDIO_INFO))
+
+typedef struct _GstPlayerAudioInfo GstPlayerAudioInfo;
+typedef GObjectClass GstPlayerAudioInfoClass;
+GType gst_player_audio_info_get_type (void);
+
+guint         gst_player_audio_info_get_channels
+                (const GstPlayerAudioInfo* info);
+guint         gst_player_audio_info_get_sample_rate
+                (const GstPlayerAudioInfo* info);
+guint         gst_player_audio_info_get_depth
+                (const GstPlayerAudioInfo* info);
+guint         gst_player_audio_info_get_bitrate
+                (const GstPlayerAudioInfo* info);
+guint         gst_player_audio_info_get_max_bitrate
+                (const GstPlayerAudioInfo* info);
+gchar*        gst_player_audio_info_get_language
+                (const GstPlayerAudioInfo* info);
+
+#define GST_TYPE_PLAYER_SUBTITLE_INFO \
+  (gst_player_subtitle_info_get_type ())
+#define GST_PLAYER_SUBTITLE_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_SUBTITLE_INFO, GstPlayerSubtitleInfo))
+#define GST_IS_PLAYER_SUBTITLE_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_SUBTITLE_INFO))
+
+typedef struct _GstPlayerSubtitleInfo GstPlayerSubtitleInfo;
+typedef GObjectClass GstPlayerSubtitleInfoClass;
+GType gst_player_subtitle_info_get_type (void);
+
+gchar*        gst_player_subtitle_get_language
+                (const GstPlayerSubtitleInfo* info);
+
+#define GST_TYPE_PLAYER_MEDIA_INFO \
+  (gst_player_media_info_get_type())
+#define GST_PLAYER_MEDIA_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_MEDIA_INFO,GstPlayerMediaInfo))
+#define GST_PLAYER_MEDIA_INFO_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_PLAYER_MEDIA_INFO,GstPlayerMediaInfoClass))
+#define GST_IS_PLAYER_MEDIA_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_MEDIA_INFO))
+#define GST_IS_PLAYER_MEDIA_INFO_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_PLAYER_MEDIA_INFO))
+
+typedef struct _GstPlayerMediaInfo GstPlayerMediaInfo;
+typedef GObjectClass GstPlayerMediaInfoClass;
+GType gst_player_media_info_get_type (void);
+
+gchar*        gst_player_media_info_get_uri
+                (const GstPlayerMediaInfo *info);
+GstClockTime  gst_player_media_info_get_duration
+                (const GstPlayerMediaInfo *info);
+GList*        gst_player_media_info_get_stream_list
+                (const GstPlayerMediaInfo *info);
+void          gst_player_stream_info_list_free
+                (GList *list);
+GList*        gst_player_get_video_streams
+                (const GstPlayerMediaInfo *info);
+GList*        gst_player_get_audio_streams
+                (const GstPlayerMediaInfo *info);
+GList*        gst_player_get_subtitle_streams
+                (const GstPlayerMediaInfo *info);
+
+G_END_DECLS
+
+#endif // __GST_PLAYER_MEDIA_INFO_H

--- a/lib/gst/player/gstplayer.h
+++ b/lib/gst/player/gstplayer.h
@@ -22,6 +22,7 @@
 #define __GST_PLAYER_H__
 
 #include <gst/gst.h>
+#include <gst/player/gstplayer-media-info.h>
 
 G_BEGIN_DECLS
 
@@ -108,6 +109,29 @@ void         gst_player_set_window_handle             (GstPlayer    * player,
                                                        gpointer       val);
 
 GstElement * gst_player_get_pipeline                  (GstPlayer    * player);
+
+void          gst_player_video_track_disable          (GstPlayer    * player);
+
+void          gst_player_audio_track_disable          (GstPlayer    * player);
+
+void          gst_player_subtitle_track_disable       (GstPlayer    * player);
+
+void          gst_player_video_track_enable           (GstPlayer    * player);
+
+void          gst_player_audio_track_enable           (GstPlayer    * player);
+
+void          gst_player_subtitle_track_enable        (GstPlayer    * player);
+
+void          gst_player_set_track                    (GstPlayer    * player,
+                                                       GstPlayerStreamInfo *s);
+
+GstPlayerMediaInfo * gst_player_get_media_info        (GstPlayer    * player);
+
+GstPlayerAudioInfo * gst_player_get_audio_track       (GstPlayer    * player);
+
+GstPlayerVideoInfo * gst_player_get_video_track       (GstPlayer    * player);
+
+GstPlayerSubtitleInfo * gst_player_get_subtitle_track (GstPlayer    * player);
 
 G_END_DECLS
 


### PR DESCRIPTION
I have incorporated your review feedback in this commit. GstPlayerMediaInfo should be immutable now. In addition I check if pipeline prerolled state, if its prerolled then create a new GstPlayerMediaInfo object  (contain copy of all available streams) and emit this newly created GstPlayerMediaInfo object. 

