### PR TITLE
mediainfo-v5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_SUBST(LT_AGE)
 PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES(GLIB, [glib-2.0 gobject-2.0])
-PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 >= 1.4 gstreamer-video-1.0 >= 1.4])
+PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0 >= 1.4 gstreamer-video-1.0 >= 1.4 gstreamer-tag-1.0 >= 1.4])
 
 GLIB_PREFIX="`$PKG_CONFIG --variable=prefix glib-2.0`"
 AC_SUBST(GLIB_PREFIX)

--- a/gst-play/gst-play.c
+++ b/gst-play/gst-play.c
@@ -110,6 +110,222 @@ buffering_cb (GstPlayer * player, gint percent, GstPlay * play)
   g_print ("Buffering: %d\n", percent);
 }
 
+static void
+print_one_tag (const GstTagList *list, const gchar *tag, gpointer user_data)
+{
+  gint i, num;
+
+  num = gst_tag_list_get_tag_size (list, tag);
+  for (i = 0; i < num; ++i) {
+    const GValue *val;
+
+    val = gst_tag_list_get_value_index (list, tag, i);
+    if (G_VALUE_HOLDS_STRING (val)) {
+      g_print ("    %s : %s \n", tag, g_value_get_string (val));
+    }
+    else if (G_VALUE_HOLDS_UINT (val)) {
+      g_print ("    %s : %u \n", tag, g_value_get_uint (val));
+    }
+    else if (G_VALUE_HOLDS_DOUBLE (val)) {
+      g_print ("    %s : %g \n", tag, g_value_get_double (val));
+    }
+    else if (G_VALUE_HOLDS_BOOLEAN (val)) {
+      g_print ("    %s : %s \n", tag,
+                g_value_get_boolean (val) ? "true" : "false");
+    }
+    else if (GST_VALUE_HOLDS_DATE_TIME (val)) {
+      GstDateTime *dt = g_value_get_boxed (val);
+      gchar *dt_str = gst_date_time_to_iso8601_string (dt);
+
+      g_print ("    %s : %s \n", tag, dt_str);
+      g_free (dt_str);
+    }
+    else {
+      g_print ("    %s : tag of type '%s' \n", tag, G_VALUE_TYPE_NAME (val));
+    }
+  }
+}
+
+static void
+print_video_info (GstPlayerVideoInfo *info)
+{
+  gint fps_n, fps_d;
+  guint par_n, par_d;
+
+  if (info == NULL)
+    return;
+
+  g_print ("  width : %d\n", gst_player_video_info_get_width(info));
+  g_print ("  height : %d\n", gst_player_video_info_get_height (info));
+  g_print ("  max_bitrate : %d\n", gst_player_video_info_get_max_bitrate (info));
+  g_print ("  bitrate : %d\n", gst_player_video_info_get_bitrate (info));
+  gst_player_video_info_get_framerate (info, &fps_n, &fps_d);
+  g_print ("  frameate : %.2f\n", (gdouble) fps_n/fps_d);
+  gst_player_video_info_get_pixel_aspect_ratio (info, &par_n, &par_d);
+  g_print ("  pixel-aspect-ratio  %u:%u\n", par_n, par_d);
+}
+
+static void
+print_audio_info (GstPlayerAudioInfo *info)
+{
+  if (info == NULL)
+    return;
+
+  g_print ("  sample rate : %d\n", gst_player_audio_info_get_sample_rate (info));
+  g_print ("  channels : %d\n", gst_player_audio_info_get_channels (info));
+  g_print ("  max_bitrate : %d\n", gst_player_audio_info_get_max_bitrate (info));
+  g_print ("  bitrate : %d\n", gst_player_audio_info_get_bitrate (info));
+  g_print ("  language : %s\n", gst_player_audio_info_get_language (info));
+}
+
+static void
+print_subtitle_info (GstPlayerSubtitleInfo *info)
+{
+  if (info == NULL)
+    return;
+
+  g_print ("  language : %s\n", gst_player_subtitle_get_language (info));
+}
+
+static void
+print_all_stream_info (GstPlayerMediaInfo *media_info)
+{
+  guint count = 0;
+  GList *l, *list;
+
+  list = gst_player_media_info_get_stream_list (media_info);
+  g_print ("URI : %s\n", gst_player_media_info_get_uri (media_info));
+  g_print ("Duration: %" GST_TIME_FORMAT "\n",
+      GST_TIME_ARGS(gst_player_media_info_get_duration (media_info)));
+  for (l = list; l != NULL; l = l->next) {
+    GstTagList  *tags = NULL;
+    GstPlayerStreamInfo *stream = (GstPlayerStreamInfo*) l->data;
+
+    g_print (" Stream # %u \n", count++);
+    g_print ("  type : %s_%u\n",
+              gst_player_stream_info_get_stream_type_nick (stream),
+              gst_player_stream_info_get_stream_index (stream));
+    tags = gst_player_stream_info_get_stream_tags (stream);
+    g_print ("  taglist : \n");
+    if (tags) {
+      gst_tag_list_foreach (tags, print_one_tag, NULL);
+    }
+
+    if (GST_IS_PLAYER_VIDEO_INFO (stream))
+      print_video_info ((GstPlayerVideoInfo*)stream);
+    else if (GST_IS_PLAYER_AUDIO_INFO (stream))
+      print_audio_info ((GstPlayerAudioInfo*)stream);
+    else
+      print_subtitle_info ((GstPlayerSubtitleInfo*)stream);
+  }
+}
+
+static void
+print_all_video_stream (GstPlayerMediaInfo *media_info)
+{
+  GList *list = NULL, *l;
+
+  list = gst_player_get_video_streams (media_info);
+  if (!list)
+    return;
+
+  g_print ("All video streams\n");
+  for (l = list; l != NULL; l = l->next) {
+    GstPlayerVideoInfo  *info = (GstPlayerVideoInfo*) l->data;
+    GstPlayerStreamInfo *sinfo = (GstPlayerStreamInfo*) info;
+    g_print (" %s_%d #\n", gst_player_stream_info_get_stream_type_nick (sinfo),
+            gst_player_stream_info_get_stream_index (sinfo));
+    print_video_info (info);
+  }
+}
+
+static void
+print_all_subtitle_stream (GstPlayerMediaInfo *media_info)
+{
+  GList *list = NULL, *l;
+
+  list = gst_player_get_subtitle_streams (media_info);
+  if (!list)
+    return;
+
+  g_print ("All subtitle streams:\n");
+  for (l = list; l != NULL; l = l->next) {
+    GstPlayerSubtitleInfo  *info = (GstPlayerSubtitleInfo*) l->data;
+    GstPlayerStreamInfo *sinfo = (GstPlayerStreamInfo*) info;
+    g_print (" %s_%d #\n", gst_player_stream_info_get_stream_type_nick (sinfo),
+    gst_player_stream_info_get_stream_index (sinfo));
+    print_subtitle_info (info);
+  }
+}
+
+static void
+print_all_audio_stream (GstPlayerMediaInfo *media_info)
+{
+  GList *list = NULL, *l;
+
+  list = gst_player_get_audio_streams (media_info);
+  if (!list)
+    return;
+
+  g_print ("All audio streams: \n");
+  for (l = list; l != NULL; l = l->next) {
+    GstPlayerAudioInfo  *info = (GstPlayerAudioInfo*) l->data;
+    GstPlayerStreamInfo *sinfo = (GstPlayerStreamInfo*) info;
+    g_print (" %s_%d #\n", gst_player_stream_info_get_stream_type_nick (sinfo),
+              gst_player_stream_info_get_stream_index (sinfo));
+    print_audio_info (info);
+  }
+}
+
+static void
+print_current_tracks (GstPlay *play)
+{
+  GstPlayerAudioInfo *audio = NULL;
+  GstPlayerVideoInfo *video = NULL;
+  GstPlayerSubtitleInfo *subtitle = NULL;
+
+  g_print ("Current video track: \n");
+  video = gst_player_get_current_video_track (play->player);
+  print_video_info (video);
+
+  g_print ("Current audio track: \n");
+  audio = gst_player_get_current_audio_track (play->player);
+  print_audio_info (audio);
+
+  g_print ("Current subtitle track: \n");
+  subtitle = gst_player_get_current_subtitle_track (play->player);
+  print_subtitle_info (subtitle);
+
+  if (audio)
+    g_object_unref (audio);
+
+  if (video)
+    g_object_unref (video);
+
+  if (subtitle)
+    g_object_unref (subtitle);
+}
+
+static void
+print_media_info (GstPlayerMediaInfo *media_info)
+{
+  if (!media_info)
+    return;
+
+  print_all_stream_info (media_info);
+  g_print ("\n");
+  print_all_video_stream (media_info);
+  g_print ("\n");
+  print_all_audio_stream (media_info);
+  g_print ("\n");
+  print_all_subtitle_stream (media_info);
+}
+
+static void
+media_info_cb (GstPlayer *player, GstPlayerMediaInfo *info, GstPlay *play)
+{
+}
+
 static GstPlay *
 play_new (gchar ** uris, gdouble initial_volume)
 {
@@ -133,6 +349,9 @@ play_new (gchar ** uris, gdouble initial_volume)
   g_signal_connect (play->player, "end-of-stream",
       G_CALLBACK (end_of_stream_cb), play);
   g_signal_connect (play->player, "error", G_CALLBACK (error_cb), play);
+
+  g_signal_connect (play->player, "media-info-updated",
+      G_CALLBACK (media_info_cb), play);
 
   play->loop = g_main_loop_new (NULL, FALSE);
   play->desired_state = GST_STATE_PLAYING;
@@ -347,6 +566,15 @@ keyboard_cb (const gchar * key_input, gpointer user_data)
   GstPlay *play = (GstPlay *) user_data;
 
   switch (g_ascii_tolower (key_input[0])) {
+    case 'i':
+      {
+        GstPlayerMediaInfo *media_info = gst_player_get_media_info (play->player);
+        print_media_info (media_info);
+        if (media_info)
+          g_object_unref (media_info);
+        print_current_tracks (play);
+        break;
+      }
     case ' ':
       toggle_paused (play);
       break;

--- a/lib/gst/player/Makefile.am
+++ b/lib/gst/player/Makefile.am
@@ -1,7 +1,8 @@
 lib_LTLIBRARIES = libgstplayer-@GST_PLAYER_API_VERSION@.la
 
 libgstplayer_@GST_PLAYER_API_VERSION@_la_SOURCES = \
-	gstplayer.c
+	gstplayer.c  \
+	gstplayer-media-info.c
 
 libgstplayer_@GST_PLAYER_API_VERSION@_la_CFLAGS = \
 	-I$(top_srcdir)/lib \
@@ -22,9 +23,12 @@ libgstplayer_@GST_PLAYER_API_VERSION@_la_LIBADD = \
 
 libgstplayerdir = $(includedir)/gst-player-@GST_PLAYER_API_VERSION@/gst/player
 
+noinst_HEADERS = gstplayer-media-info-private.h
+
 libgstplayer_HEADERS = \
 	player.h \
-	gstplayer.h
+	gstplayer.h \
+	gstplayer-media-info.h
 
 CLEANFILES =
 
@@ -51,6 +55,7 @@ GstPlayer-@GST_PLAYER_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstplayer-@G
 		--libtool="${LIBTOOL}" \
 		--pkg gobject-2.0 \
 		--pkg gstreamer-1.0 \
+		--pkg gstreamer-tag-1.0 \
 		--pkg-export gstreamer-player-@GST_PLAYER_API_VERSION@ \
 		--add-init-section="gst_init(NULL,NULL);" \
 		--output $@ \

--- a/lib/gst/player/gstplayer-media-info-private.h
+++ b/lib/gst/player/gstplayer-media-info-private.h
@@ -1,0 +1,87 @@
+/* GStreamer
+ * Copyright (C) 2015 Brijesh Singh <brijesh.ksingh@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "gstplayer-media-info.h"
+
+struct _GstPlayerStreamInfo
+{
+  GObject parent;
+
+  GstCaps *caps;
+  gint stream_index;
+  GstTagList  *tags;
+};
+
+struct _GstPlayerSubtitleInfo
+{
+  GstPlayerStreamInfo  parent;
+
+  gchar *language;
+};
+
+struct _GstPlayerAudioInfo
+{
+  GstPlayerStreamInfo  parent;
+
+  gint channels;
+  gint sample_rate;
+
+  guint bitrate;
+  guint max_bitrate;
+
+  gchar *language;
+};
+
+struct _GstPlayerVideoInfo
+{
+  GstPlayerStreamInfo  parent;
+
+  gint width;
+  gint height;
+  gint framerate_num;
+  gint framerate_denom;
+  gint par_num;
+  gint par_denom;
+
+  guint bitrate;
+  guint max_bitrate;
+};
+
+struct _GstPlayerMediaInfo
+{
+  GObject parent;
+
+  gchar *uri;
+
+  GList *stream_list;
+  GList *audio_cachelist;
+  GList *video_cachelist;
+  GList *subtitle_cachelist;
+
+  GstClockTime  duration;
+};
+
+G_GNUC_INTERNAL GstPlayerMediaInfo*   gst_player_media_info_new
+                                      (const gchar *uri);
+G_GNUC_INTERNAL GstPlayerMediaInfo*   gst_player_media_info_copy
+                                      (GstPlayerMediaInfo *ref);
+G_GNUC_INTERNAL GstPlayerStreamInfo*  gst_player_stream_info_new
+                                      (gint stream_index, GType type);
+G_GNUC_INTERNAL GstPlayerStreamInfo*  gst_player_stream_info_copy
+                                      (GstPlayerStreamInfo *ref);

--- a/lib/gst/player/gstplayer-media-info.c
+++ b/lib/gst/player/gstplayer-media-info.c
@@ -1,0 +1,623 @@
+#include "gstplayer-media-info.h"
+#include "gstplayer-media-info-private.h"
+
+/* Per-stream information */
+G_DEFINE_TYPE (GstPlayerStreamInfo, gst_player_stream_info, G_TYPE_OBJECT);
+
+static void
+gst_player_stream_info_init (GstPlayerStreamInfo * sinfo)
+{
+  sinfo->stream_index = -1;
+}
+
+static void
+gst_player_stream_info_finalize (GObject * object)
+{
+  GstPlayerStreamInfo *sinfo = GST_PLAYER_STREAM_INFO (object);
+
+  if (sinfo->caps)
+    gst_caps_unref (sinfo->caps);
+
+  if (sinfo->tags)
+    gst_tag_list_unref (sinfo->tags);
+
+  G_OBJECT_CLASS (gst_player_stream_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_stream_info_class_init (GObjectClass * klass)
+{
+  klass->finalize = gst_player_stream_info_finalize;
+}
+
+/**
+ * gst_player_stream_info_get_stream_index:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: the stream index of this stream.
+ */
+gint
+gst_player_stream_info_get_stream_index (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), -1);
+
+  return info->stream_index;
+}
+
+/**
+ * gst_player_stream_info_get_stream_type_nick:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: a human readable name for the stream type of the given @info (ex : "audio",
+ * "video",...).
+ */
+const gchar*
+gst_player_stream_info_get_stream_type_nick (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), NULL);
+
+  if (GST_IS_PLAYER_VIDEO_INFO (info))
+    return "video";
+
+  if (GST_IS_PLAYER_AUDIO_INFO (info))
+    return "audio";
+
+  if (GST_IS_PLAYER_SUBTITLE_INFO (info))
+    return "subtitle";
+
+  return NULL;
+}
+
+/**
+ * gst_player_stream_info_get_tags:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: (transfer none): the tags contained in this stream.
+ */
+GstTagList*
+gst_player_stream_info_get_stream_tags (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), NULL);
+
+  return info->tags;
+}
+
+/**
+ * gst_player_stream_info_get_caps:
+ * @info: a #GstPlayerStreamInfo
+ *
+ * Returns: (transfer none): the #GstCaps of the stream.
+ */
+GstCaps*
+gst_player_stream_info_get_stream_caps (const GstPlayerStreamInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_STREAM_INFO (info), NULL);
+
+  return info->caps;
+}
+
+/* Video information */
+G_DEFINE_TYPE (GstPlayerVideoInfo, gst_player_video_info,
+    GST_TYPE_PLAYER_STREAM_INFO);
+
+static void
+gst_player_video_info_init (GstPlayerVideoInfo * info)
+{
+  info->width = -1;
+  info->height = -1;
+  info->framerate_num = 0;
+  info->framerate_denom = 1;
+  info->par_num = 1;
+  info->par_denom = 1;
+}
+
+static void
+gst_player_video_info_class_init (GObjectClass * klass)
+{
+  /* nothing to do here */
+}
+
+/**
+ * gst_player_video_info_get_width:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the width of video in #GstPlayerVideoInfo.
+ */
+gint
+gst_player_video_info_get_width (const GstPlayerVideoInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->width;
+}
+
+/**
+ * gst_player_video_info_get_height:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the height of video in #GstPlayerVideoInfo.
+ */
+gint
+gst_player_video_info_get_height (const GstPlayerVideoInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->height;
+}
+
+/**
+ * gst_player_video_info_get_framerate_num:
+ * @info: a #GstPlayerVideoInfo
+ *
+ */
+void
+gst_player_video_info_get_framerate (const GstPlayerVideoInfo *info,
+  gint *fps_n, gint *fps_d)
+{
+  g_return_if_fail (GST_IS_PLAYER_VIDEO_INFO (info));
+
+  *fps_n = info->framerate_num;
+  *fps_d = info->framerate_denom;
+}
+
+/**
+ * gst_player_video_info_get_pixel_aspect_ratio:
+ * @info: a #GstPlayerVideoInfo
+ *
+ */
+void
+gst_player_video_info_get_pixel_aspect_ratio (const GstPlayerVideoInfo *info,
+  guint *par_d, guint *par_n)
+{
+  g_return_if_fail (GST_IS_PLAYER_VIDEO_INFO (info));
+
+  *par_n = info->par_num;
+  *par_d = info->par_denom;
+}
+
+/**
+ * gst_player_video_info_get_bitrate:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the current bitrate of video in #GstPlayerVideoInfo.
+ */
+gint
+gst_player_video_info_get_bitrate (const GstPlayerVideoInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->bitrate;
+}
+
+/**
+ * gst_player_video_info_get_max_bitrate:
+ * @info: a #GstPlayerVideoInfo
+ *
+ * Returns: the maximum bitrate of video in #GstPlayerVideoInfo.
+ */
+gint
+gst_player_video_info_get_max_bitrate (const GstPlayerVideoInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_VIDEO_INFO (info), -1);
+
+  return info->max_bitrate;
+}
+
+/* Audio information */
+G_DEFINE_TYPE (GstPlayerAudioInfo, gst_player_audio_info,
+    GST_TYPE_PLAYER_STREAM_INFO);
+
+static void
+gst_player_audio_info_init (GstPlayerAudioInfo * info)
+{
+  info->channels = 0;
+  info->sample_rate = 0;
+  info->bitrate = -1;
+  info->max_bitrate = -1;
+}
+
+static void
+gst_player_audio_info_finalize (GObject * object)
+{
+  GstPlayerAudioInfo *info = GST_PLAYER_AUDIO_INFO (object);
+
+  g_free (info->language);
+
+  G_OBJECT_CLASS (gst_player_audio_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_audio_info_class_init (GObjectClass * klass)
+{
+  klass->finalize = gst_player_audio_info_finalize;
+}
+
+/**
+ * gst_player_audio_info_get_language:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the language of the stream, or NULL if unknown.
+ */
+const gchar*
+gst_player_audio_info_get_language(const GstPlayerAudioInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), NULL);
+
+ return info->language;
+}
+
+/**
+ * gst_player_audio_info_get_channels:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the number of audio channels in #GstPlayerAudioInfo.
+ */
+gint
+gst_player_audio_info_get_channels (const GstPlayerAudioInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), 0);
+
+  return info->channels;
+}
+
+/**
+ * gst_player_audio_info_get_sample_rate:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the audio sample rate in #GstPlayerAudioInfo.
+ */
+gint
+gst_player_audio_info_get_sample_rate (const GstPlayerAudioInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), 0);
+
+  return info->sample_rate;
+}
+
+/**
+ * gst_player_audio_info_get_bitrate:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the audio bitrate in #GstPlayerAudioInfo.
+ */
+gint
+gst_player_audio_info_get_bitrate (const GstPlayerAudioInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), -1);
+
+  return info->bitrate;
+}
+
+/**
+ * gst_player_audio_info_get_max_bitrate:
+ * @info: a #GstPlayerAudioInfo
+ *
+ * Returns: the audio maximum bitrate in #GstPlayerAudioInfo.
+ */
+gint
+gst_player_audio_info_get_max_bitrate (const GstPlayerAudioInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_AUDIO_INFO (info), -1);
+
+  return info->max_bitrate;
+}
+
+/* Subtitle information */
+G_DEFINE_TYPE (GstPlayerSubtitleInfo, gst_player_subtitle_info,
+    GST_TYPE_PLAYER_STREAM_INFO);
+
+static void
+gst_player_subtitle_info_init (GstPlayerSubtitleInfo * info)
+{
+  /* nothing to do */
+}
+
+static void
+gst_player_subtitle_info_finalize (GObject * object)
+{
+  GstPlayerSubtitleInfo *info = GST_PLAYER_SUBTITLE_INFO (object);
+
+  if (info->language)
+    g_free (info->language);
+
+  G_OBJECT_CLASS (gst_player_subtitle_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_subtitle_info_class_init (GObjectClass * klass)
+{
+  klass->finalize = gst_player_subtitle_info_finalize;
+}
+
+/**
+ * gst_player_subtitle_get_language:
+ * @info: a #GstPlayerSubtitleInfo
+ *
+ * Returns: the language of the stream, or NULL if unknown.
+ */
+const gchar*
+gst_player_subtitle_get_language( const GstPlayerSubtitleInfo* info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_SUBTITLE_INFO (info), NULL);
+
+  return info->language;
+}
+
+/* Global media information */
+G_DEFINE_TYPE (GstPlayerMediaInfo, gst_player_media_info, G_TYPE_OBJECT);
+
+static void
+gst_player_media_info_init (GstPlayerMediaInfo * info)
+{
+  info->duration = -1;
+}
+
+static void
+gst_player_media_info_finalize (GObject * object)
+{
+  GstPlayerMediaInfo  *info = GST_PLAYER_MEDIA_INFO (object);
+
+  g_free (info->uri);
+
+  if (info->audio_cachelist)
+    g_list_free (info->audio_cachelist);
+
+  if (info->video_cachelist)
+    g_list_free (info->video_cachelist);
+
+  if (info->subtitle_cachelist)
+    g_list_free (info->subtitle_cachelist);
+
+  if (info->stream_list)
+    g_list_free_full (info->stream_list, g_object_unref);
+
+  G_OBJECT_CLASS (gst_player_media_info_parent_class)->finalize (object);
+}
+
+static void
+gst_player_media_info_class_init (GstPlayerMediaInfoClass * klass)
+{
+  GObjectClass  *oclass = (GObjectClass *) klass;
+
+  oclass->finalize = gst_player_media_info_finalize;
+}
+
+static GstPlayerVideoInfo*
+gst_player_video_info_new (void)
+{
+  return g_object_new (GST_TYPE_PLAYER_VIDEO_INFO, NULL);
+}
+
+static GstPlayerAudioInfo*
+gst_player_audio_info_new (void)
+{
+  return g_object_new (GST_TYPE_PLAYER_AUDIO_INFO, NULL);
+}
+
+static GstPlayerSubtitleInfo*
+gst_player_subtitle_info_new (void)
+{
+  return g_object_new (GST_TYPE_PLAYER_SUBTITLE_INFO, NULL);
+}
+
+static GstPlayerStreamInfo*
+gst_player_video_info_copy (GstPlayerVideoInfo *ref)
+{
+  GstPlayerVideoInfo *ret;
+
+  ret = gst_player_video_info_new ();
+
+  ret->width = ref->width;
+  ret->height  = ref->height;
+  ret->framerate_num = ref->framerate_num;
+  ret->framerate_denom = ref->framerate_denom;
+  ret->par_num = ref->par_num;
+  ret->par_denom = ref->par_denom;
+  ret->bitrate = ref->bitrate;
+  ret->max_bitrate = ref->max_bitrate;
+
+  return (GstPlayerStreamInfo*) ret;
+}
+
+static GstPlayerStreamInfo*
+gst_player_audio_info_copy (GstPlayerAudioInfo *ref)
+{
+  GstPlayerAudioInfo *ret;
+
+  ret = gst_player_audio_info_new ();
+
+  ret->sample_rate = ref->sample_rate;
+  ret->channels = ref->channels;
+  ret->bitrate = ref->bitrate;
+  ret->max_bitrate = ref->max_bitrate;
+
+  if (ref->language)
+    ret->language = g_strdup (ref->language);
+
+  return (GstPlayerStreamInfo*) ret;
+}
+
+static GstPlayerStreamInfo*
+gst_player_subtitle_info_copy (GstPlayerSubtitleInfo *ref)
+{
+  GstPlayerSubtitleInfo *ret;
+
+  ret = gst_player_subtitle_info_new ();
+  if (ref->language)
+    ret->language = g_strdup (ref->language);
+
+  return (GstPlayerStreamInfo*) ret;
+}
+
+GstPlayerStreamInfo*
+gst_player_stream_info_copy (GstPlayerStreamInfo *ref)
+{
+  GstPlayerStreamInfo *info = NULL;
+
+  if (!ref)
+    return NULL;
+
+  if (GST_IS_PLAYER_VIDEO_INFO(ref))
+    info = gst_player_video_info_copy ((GstPlayerVideoInfo*)ref);
+  else if (GST_IS_PLAYER_AUDIO_INFO(ref))
+    info = gst_player_audio_info_copy ((GstPlayerAudioInfo*)ref);
+  else
+    info = gst_player_subtitle_info_copy ((GstPlayerSubtitleInfo*)ref);
+
+  info->stream_index = ref->stream_index;
+  if (ref->tags)
+    info->tags = gst_tag_list_copy (ref->tags);
+  if (ref->caps)
+    info->caps = gst_caps_copy (ref->caps);
+
+  return info;
+}
+
+GstPlayerMediaInfo*
+gst_player_media_info_copy (GstPlayerMediaInfo* ref)
+{
+  GList *l;
+  GstPlayerMediaInfo *info;
+
+  if (!ref)
+    return NULL;
+
+  info = gst_player_media_info_new (ref->uri);
+  info->duration = ref->duration;
+
+  for (l = ref->stream_list; l != NULL; l = l->next) {
+    GstPlayerStreamInfo *s;
+
+    s = gst_player_stream_info_copy((GstPlayerStreamInfo*)l->data);
+    info->stream_list = g_list_append (info->stream_list, s);
+
+    if (GST_IS_PLAYER_AUDIO_INFO(s))
+      info->audio_cachelist = g_list_append (info->audio_cachelist, s);
+    else if (GST_IS_PLAYER_VIDEO_INFO(s))
+      info->video_cachelist = g_list_append (info->video_cachelist, s);
+    else
+      info->subtitle_cachelist = g_list_append (info->subtitle_cachelist, s);
+  }
+
+  return info;
+}
+
+GstPlayerStreamInfo*
+gst_player_stream_info_new (gint stream_index, GType type)
+{
+  GstPlayerStreamInfo *info = NULL;
+
+  if (type == GST_TYPE_PLAYER_AUDIO_INFO)
+    info = (GstPlayerStreamInfo*) gst_player_audio_info_new ();
+  else if (type == GST_TYPE_PLAYER_VIDEO_INFO)
+    info = (GstPlayerStreamInfo*) gst_player_video_info_new ();
+  else
+    info = (GstPlayerStreamInfo*) gst_player_subtitle_info_new ();
+
+  info->stream_index = stream_index;
+
+  return info;
+}
+
+GstPlayerMediaInfo*
+gst_player_media_info_new (const gchar *uri)
+{
+  GstPlayerMediaInfo *info;
+
+  g_return_val_if_fail (uri != NULL, NULL);
+
+  info = g_object_new (GST_TYPE_PLAYER_MEDIA_INFO, NULL);
+  if (uri)
+    info->uri = g_strdup (uri);
+
+  return info;
+}
+
+/**
+ * gst_player_media_info_get_uri:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: the URI associated with #GstPlayerMediaInfo.
+ */
+const gchar *
+gst_player_media_info_get_uri (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  return info->uri;
+}
+
+/**
+ * gst_player_media_info_get_stream_list:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer none) (element-type GstPlayerStreamInfo): A #GList of
+ * matching #GstPlayerStreamInfo.
+ */
+GList *
+gst_player_media_info_get_stream_list (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  return info->stream_list;
+}
+
+/**
+ * gst_player_get_video_streams:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer none) (element-type GstPlayerVideoInfo): A #GList of
+ * matching #GstPlayerVideoInfo.
+ */
+GList*
+gst_player_get_video_streams (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  return info->video_cachelist;
+}
+
+/**
+ * gst_player_get_subtitle_streams:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer none) (element-type GstPlayerSubtitleInfo): A #GList of
+ * matching #GstPlayerSubtitleInfo.
+ */
+GList*
+gst_player_get_subtitle_streams (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  return info->subtitle_cachelist;
+}
+
+/**
+ * gst_player_get_audio_streams:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: (transfer none) (element-type GstPlayerAudioInfo): A #GList of
+ * matching #GstPlayerAudioInfo.
+ */
+GList*
+gst_player_get_audio_streams (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), NULL);
+
+  return info->audio_cachelist;
+}
+
+/**
+ * gst_player_media_info_get_duration:
+ * @info: a #GstPlayerMediaInfo
+ *
+ * Returns: duration of the media.
+ */
+GstClockTime
+gst_player_media_info_get_duration (const GstPlayerMediaInfo *info)
+{
+  g_return_val_if_fail (GST_IS_PLAYER_MEDIA_INFO (info), -1);
+
+  return info->duration;
+}
+

--- a/lib/gst/player/gstplayer-media-info.h
+++ b/lib/gst/player/gstplayer-media-info.h
@@ -1,0 +1,138 @@
+/* GStreamer
+ *
+ * Copyright (C) 2015 Brijesh Singh <brijesh.ksingh@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_PLAYER_MEDIA_INFO_H__
+#define __GST_PLAYER_MEDIA_INFO_H__
+
+#include <gst/gst.h>
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_PLAYER_STREAM_INFO \
+  (gst_player_stream_info_get_type ())
+#define GST_PLAYER_STREAM_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_STREAM_INFO,GstPlayerStreamInfo))
+#define GST_IS_PLAYER_STREAM_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_STREAM_INFO))
+
+typedef struct _GstPlayerStreamInfo GstPlayerStreamInfo;
+typedef GObjectClass GstPlayerStreamInfoClass;
+GType gst_player_stream_info_get_type (void);
+
+gint          gst_player_stream_info_get_stream_index
+                (const GstPlayerStreamInfo *info);
+const gchar*  gst_player_stream_info_get_stream_type_nick
+                (const GstPlayerStreamInfo *info);
+GstTagList*   gst_player_stream_info_get_stream_tags
+                (const GstPlayerStreamInfo *info);
+GstCaps*      gst_player_stream_info_get_stream_caps
+                (const GstPlayerStreamInfo *info);
+
+#define GST_TYPE_PLAYER_VIDEO_INFO \
+  (gst_player_video_info_get_type ())
+#define GST_PLAYER_VIDEO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_VIDEO_INFO, GstPlayerVideoInfo))
+#define GST_IS_PLAYER_VIDEO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_VIDEO_INFO))
+
+typedef struct _GstPlayerVideoInfo GstPlayerVideoInfo;
+typedef GObjectClass GstPlayerVideoInfoClass;
+GType gst_player_video_info_get_type (void);
+
+gint          gst_player_video_info_get_bitrate
+                (const GstPlayerVideoInfo* info);
+gint          gst_player_video_info_get_max_bitrate
+                (const GstPlayerVideoInfo* info);
+gint          gst_player_video_info_get_width
+                (const GstPlayerVideoInfo* info);
+gint          gst_player_video_info_get_height
+                (const GstPlayerVideoInfo* info);
+void          gst_player_video_info_get_framerate
+                (const GstPlayerVideoInfo* info, gint *fps_n, gint *fps_d);
+void          gst_player_video_info_get_pixel_aspect_ratio
+                (const GstPlayerVideoInfo* info, guint *par_n, guint *par_d);
+
+#define GST_TYPE_PLAYER_AUDIO_INFO \
+  (gst_player_audio_info_get_type ())
+#define GST_PLAYER_AUDIO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_AUDIO_INFO, GstPlayerAudioInfo))
+#define GST_IS_PLAYER_AUDIO_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_AUDIO_INFO))
+
+typedef struct _GstPlayerAudioInfo GstPlayerAudioInfo;
+typedef GObjectClass GstPlayerAudioInfoClass;
+GType gst_player_audio_info_get_type (void);
+
+gint          gst_player_audio_info_get_channels
+                (const GstPlayerAudioInfo* info);
+gint          gst_player_audio_info_get_sample_rate
+                (const GstPlayerAudioInfo* info);
+gint          gst_player_audio_info_get_bitrate
+                (const GstPlayerAudioInfo* info);
+gint          gst_player_audio_info_get_max_bitrate
+                (const GstPlayerAudioInfo* info);
+const gchar*  gst_player_audio_info_get_language
+                (const GstPlayerAudioInfo* info);
+
+#define GST_TYPE_PLAYER_SUBTITLE_INFO \
+  (gst_player_subtitle_info_get_type ())
+#define GST_PLAYER_SUBTITLE_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_SUBTITLE_INFO, GstPlayerSubtitleInfo))
+#define GST_IS_PLAYER_SUBTITLE_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_SUBTITLE_INFO))
+
+typedef struct _GstPlayerSubtitleInfo GstPlayerSubtitleInfo;
+typedef GObjectClass GstPlayerSubtitleInfoClass;
+GType gst_player_subtitle_info_get_type (void);
+
+const gchar*  gst_player_subtitle_get_language
+                (const GstPlayerSubtitleInfo* info);
+
+#define GST_TYPE_PLAYER_MEDIA_INFO \
+  (gst_player_media_info_get_type())
+#define GST_PLAYER_MEDIA_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_PLAYER_MEDIA_INFO,GstPlayerMediaInfo))
+#define GST_PLAYER_MEDIA_INFO_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_PLAYER_MEDIA_INFO,GstPlayerMediaInfoClass))
+#define GST_IS_PLAYER_MEDIA_INFO(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_PLAYER_MEDIA_INFO))
+#define GST_IS_PLAYER_MEDIA_INFO_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_PLAYER_MEDIA_INFO))
+
+typedef struct _GstPlayerMediaInfo GstPlayerMediaInfo;
+typedef GObjectClass GstPlayerMediaInfoClass;
+GType gst_player_media_info_get_type (void);
+
+const gchar*  gst_player_media_info_get_uri
+                (const GstPlayerMediaInfo *info);
+GstClockTime  gst_player_media_info_get_duration
+                (const GstPlayerMediaInfo *info);
+GList*        gst_player_media_info_get_stream_list
+                (const GstPlayerMediaInfo *info);
+GList*        gst_player_get_video_streams
+                (const GstPlayerMediaInfo *info);
+GList*        gst_player_get_audio_streams
+                (const GstPlayerMediaInfo *info);
+GList*        gst_player_get_subtitle_streams
+                (const GstPlayerMediaInfo *info);
+
+G_END_DECLS
+
+#endif // __GST_PLAYER_MEDIA_INFO_H

--- a/lib/gst/player/gstplayer.c
+++ b/lib/gst/player/gstplayer.c
@@ -44,9 +44,11 @@
  */
 
 #include "gstplayer.h"
+#include "gstplayer-media-info-private.h"
 
 #include <gst/gst.h>
 #include <gst/video/video.h>
+#include <gst/tag/tag.h>
 
 GST_DEBUG_CATEGORY_STATIC (gst_player_debug);
 #define GST_CAT_DEFAULT gst_player_debug
@@ -85,8 +87,16 @@ enum
   SIGNAL_END_OF_STREAM,
   SIGNAL_ERROR,
   SIGNAL_VIDEO_DIMENSIONS_CHANGED,
+  SIGNAL_MEDIA_INFO_UPDATED,
   SIGNAL_LAST
 };
+
+enum {
+  GST_PLAY_FLAG_VIDEO = (1 << 0),
+  GST_PLAY_FLAG_AUDIO = (1 << 1),
+  GST_PLAY_FLAG_SUBTITLE = (1 << 2)
+};
+
 
 struct _GstPlayerPrivate
 {
@@ -111,6 +121,8 @@ struct _GstPlayerPrivate
 
   GstPlayerState app_state;
   gint buffering;
+
+  GstPlayerMediaInfo  *media_info;
 
   /* Protected by lock */
   gboolean seek_pending;        /* Only set from main context */
@@ -138,6 +150,28 @@ static gboolean gst_player_stop_internal (gpointer user_data);
 static gboolean gst_player_pause_internal (gpointer user_data);
 static gboolean gst_player_play_internal (gpointer user_data);
 static void change_state (GstPlayer * self, GstPlayerState state);
+
+static GstPlayerMediaInfo* gst_player_media_info_create (GstPlayer *self);
+
+static void gst_player_streams_info_create (GstPlayer *self,
+    GstPlayerMediaInfo *media_info, const gchar *prop, GType type);
+static void gst_player_stream_info_update (GstPlayer *self,
+    GstPlayerStreamInfo *s);
+static void gst_player_stream_info_update_tags_and_caps (GstPlayer *self,
+    GstPlayerStreamInfo *s);
+static GstPlayerStreamInfo* gst_player_stream_info_find (GstPlayer *self,
+    GstPlayerMediaInfo *media_info, GType type, gint stream_index);
+static GstPlayerStreamInfo* gst_player_stream_info_get_current(
+    GstPlayer *self, const gchar *prop, GType type);
+
+static void gst_player_video_info_update (GstPlayer *self,
+    GstPlayerStreamInfo *stream_info);
+static void gst_player_audio_info_update (GstPlayer *self,
+    GstPlayerStreamInfo *stream_info);
+static void gst_player_subtitle_info_update (GstPlayer *self,
+    GstPlayerStreamInfo *stream_info);
+
+static void emit_media_info_updated_signal (GstPlayer *self);
 
 static void
 gst_player_init (GstPlayer * self)
@@ -240,6 +274,11 @@ gst_player_class_init (GstPlayerClass * klass)
       g_signal_new ("video-dimensions-changed", G_TYPE_FROM_CLASS (klass),
       G_SIGNAL_RUN_LAST | G_SIGNAL_NO_RECURSE | G_SIGNAL_NO_HOOKS, 0, NULL,
       NULL, NULL, G_TYPE_NONE, 2, G_TYPE_INT, G_TYPE_INT);
+
+  signals[SIGNAL_MEDIA_INFO_UPDATED] =
+      g_signal_new ("media-info-updated", G_TYPE_FROM_CLASS (klass),
+      G_SIGNAL_RUN_LAST | G_SIGNAL_NO_RECURSE | G_SIGNAL_NO_HOOKS, 0, NULL,
+      NULL, NULL, G_TYPE_NONE, 1, GST_TYPE_PLAYER_MEDIA_INFO);
 }
 
 static void
@@ -941,6 +980,11 @@ state_changed_cb (GstBus * bus, GstMessage * msg, gpointer user_data)
 
       GST_DEBUG_OBJECT (self, "Initial PAUSED - pre-rolled");
 
+      g_mutex_lock (&self->priv->lock);
+      self->priv->media_info = gst_player_media_info_create (self);
+      g_mutex_unlock (&self->priv->lock);
+      emit_media_info_updated_signal (self);
+
       g_object_get (self->priv->playbin, "video-sink", &video_sink, NULL);
 
       if (video_sink) {
@@ -1121,6 +1165,512 @@ element_cb (GstBus * bus, GstMessage * msg, gpointer user_data)
   }
 }
 
+static void
+player_set_flag (GstPlayer *self, gint pos)
+{
+  gint flags;
+
+  g_object_get (self->priv->playbin, "flags", &flags, NULL);
+  flags |= pos;
+  g_object_set (self->priv->playbin, "flags", &flags, NULL);
+}
+
+static void
+player_clear_flag (GstPlayer *self, gint pos)
+{
+  gint flags;
+
+  g_object_get (self->priv->playbin, "flags", &flags, NULL);
+  flags &= ~pos;
+  g_object_set (self->priv->playbin, "flags", &flags, NULL);
+}
+
+typedef struct
+{
+  GstPlayer *player;
+  GstPlayerMediaInfo  *info;
+}MediaInfoUpdatedSignalData;
+
+static gboolean
+media_info_updated_dispatch (gpointer user_data)
+{
+  MediaInfoUpdatedSignalData  *data = user_data;
+
+  g_signal_emit (data->player, signals[SIGNAL_MEDIA_INFO_UPDATED], 0, data->info);
+
+  return FALSE;
+}
+
+static void
+free_media_info_updated_signal_data (MediaInfoUpdatedSignalData *data)
+{
+  GST_DEBUG_OBJECT (data->player, "media_info %p", data->info);
+  g_object_unref (data->info);
+  g_slice_free (MediaInfoUpdatedSignalData, data);
+}
+
+/*
+ * emit_media_info_updated_signal:
+ *
+ * create a new copy of self->priv->media_info object and emits the newly created
+ * copy to user application. The newly created media_info will be unref'ed
+ * as part of signal finalize method.
+ */
+static void
+emit_media_info_updated_signal (GstPlayer *self)
+{
+  if (self->priv->dispatch_to_main_context) {
+    MediaInfoUpdatedSignalData *data = g_slice_new
+                                        (MediaInfoUpdatedSignalData);
+    data->player = self;
+    g_mutex_lock (&self->priv->lock);
+    data->info = gst_player_media_info_copy (self->priv->media_info);
+    g_mutex_unlock (&self->priv->lock);
+
+    GST_DEBUG_OBJECT (self, "media_info %p", data->info);
+
+    g_main_context_invoke_full (self->priv->application_context,
+        G_PRIORITY_DEFAULT, media_info_updated_dispatch,
+        data, (GDestroyNotify) free_media_info_updated_signal_data);
+  } else {
+    g_signal_emit (self, signals[SIGNAL_MEDIA_INFO_UPDATED], 0);
+  }
+}
+
+static GstCaps*
+get_caps (GstPlayer *self, gint stream_index, GType type)
+{
+  GstPad  *pad = NULL;
+  GstCaps *caps = NULL;
+
+  if (type == GST_TYPE_PLAYER_VIDEO_INFO)
+    g_signal_emit_by_name (G_OBJECT (self->priv->playbin),
+                          "get-video-pad", stream_index, &pad);
+  else if (type == GST_TYPE_PLAYER_AUDIO_INFO)
+    g_signal_emit_by_name (G_OBJECT (self->priv->playbin),
+                          "get-audio-pad", stream_index, &pad);
+  else
+    g_signal_emit_by_name (G_OBJECT (self->priv->playbin),
+                          "get-text-pad", stream_index, &pad);
+
+  if (pad) {
+    caps = gst_pad_get_current_caps (pad);
+    gst_object_unref (pad);
+  }
+
+  return caps;
+}
+
+static void
+gst_player_subtitle_info_update (GstPlayer *self,
+  GstPlayerStreamInfo *stream_info)
+{
+  GstPlayerSubtitleInfo *info = (GstPlayerSubtitleInfo*) stream_info;
+
+  if (stream_info->tags) {
+    gchar *lang_code;
+    gchar *language;
+
+    if (info->language) {
+      g_free (info->language);
+      info->language = NULL;
+    }
+
+    /* First try to get the language full name from tag, if name is not
+     * available then try language code. If we find the language code
+     * then use gstreamer api to translate code to full name.
+     */
+    if (gst_tag_list_get_string (stream_info->tags,
+          GST_TAG_LANGUAGE_NAME, &language)) {
+      info->language = g_strdup (language);
+      g_free (language);
+    } else {
+      gst_tag_list_get_string (stream_info->tags,
+          GST_TAG_LANGUAGE_CODE, &lang_code);
+      info->language = g_strdup (gst_tag_get_language_name (lang_code));
+      g_free (lang_code);
+    }
+  }
+
+  GST_DEBUG_OBJECT (self, "language=%s", info->language);
+}
+
+static void
+gst_player_video_info_update (GstPlayer *self,
+  GstPlayerStreamInfo *stream_info)
+{
+  GstPlayerVideoInfo *info = (GstPlayerVideoInfo*) stream_info;
+
+  if (stream_info->caps) {
+    GstStructure *s;
+
+    s = gst_caps_get_structure (stream_info->caps, 0);
+    if (s) {
+      gint width, height;
+      gint fps_n, fps_d;
+      gint par_n, par_d;
+
+      if (gst_structure_get_int (s, "width", &width))
+        info->width = width;
+      else
+        info->width = -1;
+
+      if (gst_structure_get_int (s, "height", &height))
+        info->height = height;
+      else
+        info->height = -1;
+
+      if (gst_structure_get_fraction (s, "framerate", &fps_n, &fps_d)) {
+        info->framerate_num = fps_n;
+        info->framerate_denom = fps_d;
+      } else {
+        info->framerate_num = 0;
+        info->framerate_denom = 1;
+      }
+
+
+      if (gst_structure_get_fraction (s, "pixel-aspect-ratio",
+            &par_n, &par_d)) {
+        info->par_num = par_n;
+        info->par_denom = par_d;
+      } else {
+        info->par_num = 1;
+        info->par_denom = 1;
+      }
+    }
+  }
+
+  if (stream_info->tags) {
+    guint bitrate, max_bitrate;
+
+    if (gst_tag_list_get_uint (stream_info->tags, GST_TAG_BITRATE,
+          &bitrate) || gst_tag_list_get_uint (stream_info->tags,
+            GST_TAG_NOMINAL_BITRATE, &bitrate))
+      info->bitrate = bitrate;
+    else
+      info->bitrate = -1;
+
+    if (gst_tag_list_get_uint (stream_info->tags,
+          GST_TAG_MAXIMUM_BITRATE, &max_bitrate))
+      info->max_bitrate = max_bitrate;
+    else
+      info->max_bitrate = -1;
+  }
+
+  GST_DEBUG_OBJECT (self, "width=%d height=%d fps=%.2f par=%d:%d "
+      "bitrate=%d max_bitrate=%d", info->width, info->height,
+      (gdouble)info->framerate_num/info->framerate_denom,
+      info->par_num, info->par_denom, info->bitrate, info->max_bitrate);
+}
+
+static void
+gst_player_audio_info_update (GstPlayer *self,
+  GstPlayerStreamInfo *stream_info)
+{
+  GstPlayerAudioInfo *info = (GstPlayerAudioInfo*) stream_info;
+
+  if (stream_info->caps) {
+    GstStructure *s;
+
+    s = gst_caps_get_structure (stream_info->caps, 0);
+    if (s) {
+      gint rate, channels;
+
+      if (gst_structure_get_int (s, "rate", &rate))
+        info->sample_rate = rate;
+      else
+        info->sample_rate = -1;
+
+      if (gst_structure_get_int (s, "channels", &channels))
+        info->channels = channels;
+      else
+        info->channels = 0;
+    }
+  }
+
+  if (stream_info->tags) {
+    gchar *lang_code;
+    gchar *language;
+    guint bitrate, max_bitrate;
+
+    if (gst_tag_list_get_uint (stream_info->tags, GST_TAG_BITRATE,
+          &bitrate) || gst_tag_list_get_uint (stream_info->tags,
+            GST_TAG_NOMINAL_BITRATE, &bitrate))
+      info->bitrate = bitrate;
+    else
+      info->bitrate = -1;
+
+    if (gst_tag_list_get_uint (stream_info->tags,
+          GST_TAG_MAXIMUM_BITRATE, &max_bitrate))
+      info->max_bitrate = max_bitrate;
+    else
+      info->max_bitrate = -1;
+
+    if (info->language) {
+      g_free (info->language);
+      info->language = NULL;
+    }
+
+    /* First try to get the language full name from tag, if name is not
+     * available then try language code. If we find the language code
+     * then use gstreamer api to translate code to full name.
+     */
+    if (gst_tag_list_get_string (stream_info->tags,
+          GST_TAG_LANGUAGE_NAME, &language)) {
+      info->language = g_strdup (language);
+      g_free (language);
+    } else {
+      gst_tag_list_get_string (stream_info->tags,
+          GST_TAG_LANGUAGE_CODE, &lang_code);
+      info->language = g_strdup (gst_tag_get_language_name (lang_code));
+      g_free (lang_code);
+    }
+  }
+
+  GST_DEBUG_OBJECT (self, "language=%s rate=%d channels=%d bitrate=%d "
+      "max_bitrate=%d", info->language, info->sample_rate, info->channels,
+      info->bitrate, info->bitrate);
+}
+
+static GstPlayerStreamInfo*
+gst_player_stream_info_find (GstPlayer *self, GstPlayerMediaInfo *media_info,
+  GType type, gint stream_index)
+{
+  GList *list, *l;
+  GstPlayerStreamInfo *info = NULL;
+
+  if (!media_info)
+    return NULL;
+
+  list = gst_player_media_info_get_stream_list (media_info);
+  for (l = list; l != NULL; l = l->next) {
+    info = (GstPlayerStreamInfo*) l->data;
+    if ((G_OBJECT_TYPE (info) == type) &&
+        (info->stream_index == stream_index)) {
+      return info;
+    }
+  }
+
+  return NULL;
+}
+
+static gboolean
+is_track_enabled (GstPlayer *self, gint pos)
+{
+  gint flags;
+
+  g_object_get (G_OBJECT(self->priv->playbin), "flags", &flags, NULL);
+
+  if ((flags & pos))
+    return TRUE;
+
+  return FALSE;
+}
+
+static GstPlayerStreamInfo*
+gst_player_stream_info_get_current (GstPlayer *self, const gchar *prop,
+  GType type)
+{
+  gint current;
+  GstPlayerStreamInfo *info;
+
+  g_object_get (G_OBJECT(self->priv->playbin), prop, &current, NULL);
+  g_mutex_lock (&self->priv->lock);
+  info = gst_player_stream_info_find (self, self->priv->media_info,
+            type, current);
+  if (info)
+    info = gst_player_stream_info_copy (info);
+  g_mutex_unlock (&self->priv->lock);
+
+  return info;
+}
+
+static void
+gst_player_stream_info_update (GstPlayer *self, GstPlayerStreamInfo *s)
+{
+  if (GST_IS_PLAYER_VIDEO_INFO(s))
+    gst_player_video_info_update (self, s);
+  else if (GST_IS_PLAYER_AUDIO_INFO(s))
+    gst_player_audio_info_update (self, s);
+  else
+    gst_player_subtitle_info_update (self, s);
+}
+
+static void
+gst_player_stream_info_update_tags_and_caps (GstPlayer *self,
+  GstPlayerStreamInfo *s)
+{
+  GstTagList *tags;
+  gint stream_index;
+
+  stream_index = gst_player_stream_info_get_stream_index (s);
+
+  if (GST_IS_PLAYER_VIDEO_INFO(s))
+    g_signal_emit_by_name (self->priv->playbin, "get-video-tags",
+        stream_index, &tags);
+  else if (GST_IS_PLAYER_AUDIO_INFO(s))
+    g_signal_emit_by_name (self->priv->playbin, "get-audio-tags",
+        stream_index, &tags);
+  else
+    g_signal_emit_by_name (self->priv->playbin, "get-text-tags",
+        stream_index, &tags);
+
+  if (s->tags)
+    gst_tag_list_unref (s->tags);
+  s->tags = tags;
+
+  if (s->caps)
+    gst_caps_unref (s->caps);
+  s->caps = get_caps (self, stream_index, G_OBJECT_TYPE(s));
+
+  GST_DEBUG_OBJECT (self, "%s index: %d tags: %p caps: %p",
+      gst_player_stream_info_get_stream_type_nick(s), stream_index,
+      s->tags, s->caps);
+
+  gst_player_stream_info_update (self, s);
+}
+
+static void
+gst_player_streams_info_create (GstPlayer *self, GstPlayerMediaInfo *media_info,
+  const gchar *prop, GType type)
+{
+  gint i;
+  gint total = -1;
+  GstPlayerStreamInfo *s;
+
+  if (!media_info)
+    return;
+
+  g_object_get (G_OBJECT (self->priv->playbin), prop, &total, NULL);
+
+  GST_DEBUG_OBJECT (self, "%s: %d", prop, total);
+
+  for (i = 0; i < total; i++) {
+    /* check if stream already exist in the list */
+    s = gst_player_stream_info_find (self, media_info, type, i);
+
+    if (!s) {
+      /* create a new stream info instance */
+      s = gst_player_stream_info_new (i, type);
+
+      /* add the object in stream list */
+      media_info->stream_list = g_list_append (media_info->stream_list, s);
+
+      /* based on type, add the object in its corresponding cache list */
+      if (GST_IS_PLAYER_AUDIO_INFO(s))
+        media_info->audio_cachelist = g_list_append
+                                      (media_info->audio_cachelist, s);
+      else if (GST_IS_PLAYER_VIDEO_INFO(s))
+        media_info->video_cachelist = g_list_append
+                                      (media_info->video_cachelist, s);
+      else
+        media_info->subtitle_cachelist = g_list_append
+                                      (media_info->subtitle_cachelist, s);
+
+      GST_DEBUG_OBJECT (self, "create %s stream stream_index: %d",
+        gst_player_stream_info_get_stream_type_nick(s), i);
+    }
+
+    gst_player_stream_info_update_tags_and_caps (self, s);
+  }
+}
+
+static void
+video_changed_cb (GObject *object, gpointer user_data)
+{
+  GstPlayer *self = GST_PLAYER(user_data);
+
+  g_mutex_lock (&self->priv->lock);
+  gst_player_streams_info_create (self, self->priv->media_info,
+      "n-video", GST_TYPE_PLAYER_VIDEO_INFO);
+  g_mutex_unlock (&self->priv->lock);
+}
+
+static void
+audio_changed_cb (GObject *object, gpointer user_data)
+{
+  GstPlayer *self = GST_PLAYER(user_data);
+
+  g_mutex_lock (&self->priv->lock);
+  gst_player_streams_info_create (self, self->priv->media_info,
+      "n-audio", GST_TYPE_PLAYER_AUDIO_INFO);
+  g_mutex_unlock (&self->priv->lock);
+}
+
+static void
+subtitle_changed_cb (GObject *object, gpointer user_data)
+{
+  GstPlayer *self = GST_PLAYER(user_data);
+
+  g_mutex_lock (&self->priv->lock);
+  gst_player_streams_info_create (self, self->priv->media_info,
+      "n-text", GST_TYPE_PLAYER_SUBTITLE_INFO);
+  g_mutex_unlock (&self->priv->lock);
+}
+
+static GstPlayerMediaInfo*
+gst_player_media_info_create (GstPlayer *self)
+{
+  GstPlayerMediaInfo *media_info;
+
+  GST_DEBUG_OBJECT (self, "begin");
+  media_info = gst_player_media_info_new (self->priv->uri);
+  media_info->duration = gst_player_get_duration (self);
+
+  /* create audio/video/sub streams */
+  gst_player_streams_info_create (self, media_info, "n-video",
+      GST_TYPE_PLAYER_VIDEO_INFO);
+  gst_player_streams_info_create (self, media_info, "n-audio",
+      GST_TYPE_PLAYER_AUDIO_INFO);
+  gst_player_streams_info_create (self, media_info, "n-text",
+      GST_TYPE_PLAYER_SUBTITLE_INFO);
+
+  GST_DEBUG_OBJECT (self, "end");
+  return media_info;
+}
+
+static void
+tags_changed_cb (GstPlayer *self, gint stream_index, GType type)
+{
+  GstPlayerStreamInfo *s;
+
+  if (!self->priv->media_info)
+    return;
+
+  /* update the stream information */
+  g_mutex_lock (&self->priv->lock);
+  s = gst_player_stream_info_find (self, self->priv->media_info,
+          type, stream_index);
+  gst_player_stream_info_update_tags_and_caps (self, s);
+  g_mutex_unlock (&self->priv->lock);
+
+  emit_media_info_updated_signal (self);
+}
+
+static void
+video_tags_changed_cb (GstElement *playbin, gint stream_index,
+  gpointer user_data)
+{
+  tags_changed_cb (GST_PLAYER(user_data), stream_index,
+      GST_TYPE_PLAYER_VIDEO_INFO);
+}
+
+static void
+audio_tags_changed_cb (GstElement *playbin, gint stream_index,
+  gpointer user_data)
+{
+  tags_changed_cb (GST_PLAYER(user_data), stream_index,
+      GST_TYPE_PLAYER_AUDIO_INFO);
+}
+
+static void
+subtitle_tags_changed_cb (GstElement *playbin, gint stream_index,
+  gpointer user_data)
+{
+  tags_changed_cb (GST_PLAYER(user_data), stream_index,
+      GST_TYPE_PLAYER_SUBTITLE_INFO);
+}
+
 static gpointer
 gst_player_main (gpointer data)
 {
@@ -1167,6 +1717,20 @@ gst_player_main (gpointer data)
       G_CALLBACK (request_state_cb), self);
   g_signal_connect (G_OBJECT (bus), "message::element",
       G_CALLBACK (element_cb), self);
+
+  g_signal_connect (self->priv->playbin, "video-changed",
+      G_CALLBACK (video_changed_cb), self);
+  g_signal_connect (self->priv->playbin, "audio-changed",
+      G_CALLBACK (audio_changed_cb), self);
+  g_signal_connect (self->priv->playbin, "text-changed",
+      G_CALLBACK (subtitle_changed_cb), self);
+
+  g_signal_connect (self->priv->playbin, "video-tags-changed",
+      G_CALLBACK (video_tags_changed_cb), self);
+  g_signal_connect (self->priv->playbin, "audio-tags-changed",
+      G_CALLBACK (audio_tags_changed_cb), self);
+  g_signal_connect (self->priv->playbin, "text-tags-changed",
+      G_CALLBACK (subtitle_tags_changed_cb), self);
 
   self->priv->target_state = GST_STATE_NULL;
   self->priv->current_state = GST_STATE_NULL;
@@ -1379,7 +1943,10 @@ gst_player_stop_internal (gpointer user_data)
   gst_bus_set_flushing (self->priv->bus, FALSE);
   change_state (self, GST_PLAYER_STATE_STOPPED);
   self->priv->buffering = 100;
-
+  if (self->priv->media_info) {
+    g_object_unref (self->priv->media_info);
+    self->priv->media_info = NULL;
+  }
   g_mutex_lock (&self->priv->lock);
   self->priv->seek_pending = FALSE;
   if (self->priv->seek_source) {
@@ -1658,6 +2225,204 @@ gst_player_get_pipeline (GstPlayer * self)
   g_object_get (self, "pipeline", &val, NULL);
 
   return val;
+}
+
+/**
+ * gst_player_get_media_info:
+ * @player: #GstPlayer instance
+ *
+ * Returns: (transfer full): Current media info instance.
+ * the caller should free it with g_object_unref()
+ */
+GstPlayerMediaInfo*
+gst_player_get_media_info (GstPlayer *self)
+{
+  GstPlayerMediaInfo *info;
+
+  g_mutex_lock (&self->priv->lock);
+  info = gst_player_media_info_copy (self->priv->media_info);
+  g_mutex_unlock (&self->priv->lock);
+
+  return info;
+}
+
+/**
+ * gst_player_get_current_audio_track:
+ * @player: #GstPlayer instance
+ *
+ * Returns: (transfer full): current audio track
+ * the caller should free it with g_object_unref()
+ */
+GstPlayerAudioInfo*
+gst_player_get_current_audio_track (GstPlayer *self)
+{
+  GstPlayerAudioInfo *info;
+
+  if (!is_track_enabled (self, GST_PLAY_FLAG_AUDIO))
+    return NULL;
+
+  info = (GstPlayerAudioInfo*) gst_player_stream_info_get_current (self,
+            "current-audio", GST_TYPE_PLAYER_AUDIO_INFO);
+  return info;
+}
+
+/**
+ * gst_player_get_current_video_track:
+ * @player: #GstPlayer instance
+ *
+ * Returns: (transfer full): current video track
+ * the caller should free it with g_object_unref()
+ */
+GstPlayerVideoInfo*
+gst_player_get_current_video_track (GstPlayer *self)
+{
+  GstPlayerVideoInfo *info;
+
+  if (!is_track_enabled (self, GST_PLAY_FLAG_VIDEO))
+    return NULL;
+
+  info = (GstPlayerVideoInfo*) gst_player_stream_info_get_current (self,
+            "current-video", GST_TYPE_PLAYER_VIDEO_INFO);
+  return info;
+}
+
+/**
+ * gst_player_get_current_subtitle_track:
+ * @player: #GstPlayer instance
+ *
+ * Returns: (transfer none): current subtitle track
+ */
+GstPlayerSubtitleInfo*
+gst_player_get_current_subtitle_track (GstPlayer *self)
+{
+  GstPlayerSubtitleInfo *info;
+
+  if (!is_track_enabled (self, GST_PLAY_FLAG_SUBTITLE))
+    return NULL;
+
+  info = (GstPlayerSubtitleInfo*) gst_player_stream_info_get_current (self,
+            "current-text", GST_TYPE_PLAYER_SUBTITLE_INFO);
+  return info;
+}
+
+/**
+ * gst_player_set_audio_track:
+ * @player: #GstPlayer instance
+ * @stream_index: stream index
+ */
+gboolean
+gst_player_set_audio_track (GstPlayer *self, gint stream_index)
+{
+  GstPlayerStreamInfo *info;
+
+  g_mutex_lock (&self->priv->lock);
+  info = gst_player_stream_info_find (self, self->priv->media_info,
+            GST_TYPE_PLAYER_AUDIO_INFO, stream_index);
+  g_mutex_unlock (&self->priv->lock);
+  if (!info) {
+    GST_ERROR_OBJECT (self, "invalid audio stream index %d", stream_index);
+    return FALSE;
+  }
+
+  g_object_set (G_OBJECT(self->priv->playbin), "current-audio",
+                stream_index, NULL);
+  return TRUE;
+}
+
+/**
+ * gst_player_set_video_track:
+ * @player: #GstPlayer instance
+ * @stream_index: stream index
+ */
+gboolean
+gst_player_set_video_track (GstPlayer *self, gint stream_index)
+{
+  GstPlayerStreamInfo *info;
+
+  /* check if stream_index exist in our internal media_info list */
+  g_mutex_lock (&self->priv->lock);
+  info = gst_player_stream_info_find (self, self->priv->media_info,
+            GST_TYPE_PLAYER_VIDEO_INFO, stream_index);
+  g_mutex_unlock (&self->priv->lock);
+  if (!info) {
+    GST_ERROR_OBJECT (self, "invalid video stream index %d", stream_index);
+    return FALSE;
+  }
+
+  g_object_set (G_OBJECT(self->priv->playbin), "current-video",
+                stream_index, NULL);
+  return TRUE;
+}
+
+/**
+ * gst_player_set_subtitle_track:
+ * @player: #GstPlayer instance
+ * @stream_index: stream index
+ */
+gboolean
+gst_player_set_subtitle_track (GstPlayer *self, gint stream_index)
+{
+  GstPlayerStreamInfo *info;
+
+  g_mutex_lock (&self->priv->lock);
+  info = gst_player_stream_info_find (self, self->priv->media_info,
+            GST_TYPE_PLAYER_SUBTITLE_INFO, stream_index);
+  g_mutex_unlock (&self->priv->lock);
+  if (!info) {
+    GST_ERROR_OBJECT (self, "invalid subtitle stream index %d", stream_index);
+    return FALSE;
+  }
+
+  g_object_set (G_OBJECT(self->priv->playbin), "current-text",
+                stream_index, NULL);
+  return TRUE;
+}
+
+/*
+ * gst_player_set_audio_enabled:
+ * @player: #GstPlayer instance
+ * @enabled: enable or disable
+ *
+ * Enable or disable the current audio track
+ */
+void
+gst_player_set_audio_track_enabled (GstPlayer *self, gboolean enabled)
+{
+  if (enabled)
+    player_set_flag (self, GST_PLAY_FLAG_AUDIO);
+  else
+    player_clear_flag (self, GST_PLAY_FLAG_AUDIO);
+}
+
+/*
+ * gst_player_set_video_enabled:
+ * @player: #GstPlayer instance
+ * @enabled: enable or disable
+ *
+ * Enable or disable the current video track
+ */
+void
+gst_player_set_video_track_enabled (GstPlayer *self, gboolean enabled)
+{
+  if (enabled)
+    player_set_flag (self, GST_PLAY_FLAG_VIDEO);
+  else
+    player_clear_flag (self, GST_PLAY_FLAG_VIDEO);
+}
+/*
+ * gst_player_set_subtitle_enabled:
+ * @player: #GstPlayer instance
+ * @enabled: enable or disable
+ *
+ * Enable or disable the current subtitle track
+ */
+void
+gst_player_set_subtitle_track_enabled (GstPlayer *self, gboolean enabled)
+{
+  if (enabled)
+    player_set_flag (self, GST_PLAY_FLAG_SUBTITLE);
+  else
+    player_clear_flag (self, GST_PLAY_FLAG_SUBTITLE);
 }
 
 #define C_ENUM(v) ((gint) v)

--- a/lib/gst/player/gstplayer.c
+++ b/lib/gst/player/gstplayer.c
@@ -1268,8 +1268,6 @@ gst_player_subtitle_info_update (GstPlayer *self,
   GstPlayerSubtitleInfo *info = (GstPlayerSubtitleInfo*) stream_info;
 
   if (stream_info->tags) {
-    gchar *lang_code;
-    gchar *language;
 
     if (info->language) {
       g_free (info->language);
@@ -1280,15 +1278,18 @@ gst_player_subtitle_info_update (GstPlayer *self,
      * available then try language code. If we find the language code
      * then use gstreamer api to translate code to full name.
      */
-    if (gst_tag_list_get_string (stream_info->tags,
-          GST_TAG_LANGUAGE_NAME, &language)) {
-      info->language = g_strdup (language);
-      g_free (language);
-    } else {
-      gst_tag_list_get_string (stream_info->tags,
-          GST_TAG_LANGUAGE_CODE, &lang_code);
-      info->language = g_strdup (gst_tag_get_language_name (lang_code));
-      g_free (lang_code);
+    gst_tag_list_get_string (stream_info->tags, GST_TAG_LANGUAGE_NAME,
+                              &info->language);
+    if (!info->language) {
+      gchar *lang_code = NULL;
+
+      gst_tag_list_get_string (stream_info->tags, GST_TAG_LANGUAGE_CODE,
+                                &lang_code);
+      if (lang_code) {
+        info->language = g_strdup (gst_tag_get_language_name (lang_code));
+        g_free (lang_code);
+
+      }
     }
   }
 
@@ -1389,8 +1390,6 @@ gst_player_audio_info_update (GstPlayer *self,
   }
 
   if (stream_info->tags) {
-    gchar *lang_code;
-    gchar *language;
     guint bitrate, max_bitrate;
 
     if (gst_tag_list_get_uint (stream_info->tags, GST_TAG_BITRATE,
@@ -1415,15 +1414,18 @@ gst_player_audio_info_update (GstPlayer *self,
      * available then try language code. If we find the language code
      * then use gstreamer api to translate code to full name.
      */
-    if (gst_tag_list_get_string (stream_info->tags,
-          GST_TAG_LANGUAGE_NAME, &language)) {
-      info->language = g_strdup (language);
-      g_free (language);
-    } else {
-      gst_tag_list_get_string (stream_info->tags,
-          GST_TAG_LANGUAGE_CODE, &lang_code);
-      info->language = g_strdup (gst_tag_get_language_name (lang_code));
-      g_free (lang_code);
+    gst_tag_list_get_string (stream_info->tags, GST_TAG_LANGUAGE_NAME,
+                              &info->language);
+    if (!info->language) {
+      gchar *lang_code = NULL;
+
+      gst_tag_list_get_string (stream_info->tags, GST_TAG_LANGUAGE_CODE,
+                                &lang_code);
+      if (lang_code) {
+        info->language = g_strdup (gst_tag_get_language_name (lang_code));
+        g_free (lang_code);
+
+      }
     }
   }
 

--- a/lib/gst/player/gstplayer.c
+++ b/lib/gst/player/gstplayer.c
@@ -1345,14 +1345,14 @@ gst_player_video_info_update (GstPlayer *self,
     guint bitrate, max_bitrate;
 
     if (gst_tag_list_get_uint (stream_info->tags, GST_TAG_BITRATE,
-          &bitrate) || gst_tag_list_get_uint (stream_info->tags,
-            GST_TAG_NOMINAL_BITRATE, &bitrate))
+          &bitrate))
       info->bitrate = bitrate;
     else
       info->bitrate = -1;
 
-    if (gst_tag_list_get_uint (stream_info->tags,
-          GST_TAG_MAXIMUM_BITRATE, &max_bitrate))
+    if (gst_tag_list_get_uint (stream_info->tags, GST_TAG_MAXIMUM_BITRATE,
+          &max_bitrate) || gst_tag_list_get_uint (stream_info->tags,
+          GST_TAG_NOMINAL_BITRATE, &max_bitrate))
       info->max_bitrate = max_bitrate;
     else
       info->max_bitrate = -1;
@@ -1393,14 +1393,14 @@ gst_player_audio_info_update (GstPlayer *self,
     guint bitrate, max_bitrate;
 
     if (gst_tag_list_get_uint (stream_info->tags, GST_TAG_BITRATE,
-          &bitrate) || gst_tag_list_get_uint (stream_info->tags,
-            GST_TAG_NOMINAL_BITRATE, &bitrate))
+          &bitrate))
       info->bitrate = bitrate;
     else
       info->bitrate = -1;
 
-    if (gst_tag_list_get_uint (stream_info->tags,
-          GST_TAG_MAXIMUM_BITRATE, &max_bitrate))
+    if (gst_tag_list_get_uint (stream_info->tags, GST_TAG_MAXIMUM_BITRATE,
+          &max_bitrate) || gst_tag_list_get_uint (stream_info->tags,
+          GST_TAG_NOMINAL_BITRATE, &max_bitrate))
       info->max_bitrate = max_bitrate;
     else
       info->max_bitrate = -1;

--- a/lib/gst/player/gstplayer.h
+++ b/lib/gst/player/gstplayer.h
@@ -22,6 +22,7 @@
 #define __GST_PLAYER_H__
 
 #include <gst/gst.h>
+#include <gst/player/gstplayer-media-info.h>
 
 G_BEGIN_DECLS
 
@@ -108,6 +109,35 @@ void         gst_player_set_window_handle             (GstPlayer    * player,
                                                        gpointer       val);
 
 GstElement * gst_player_get_pipeline                  (GstPlayer    * player);
+
+void          gst_player_set_video_track_enabled      (GstPlayer    * player,
+                                                       gboolean enabled);
+
+void          gst_player_set_audio_track_enabled      (GstPlayer    * player,
+                                                       gboolean enabled);
+
+void          gst_player_set_subtitle_track_enabled   (GstPlayer    * player,
+                                                       gboolean enabled);
+
+gboolean      gst_player_set_audio_track              (GstPlayer    *player,
+                                                       gint stream_index);
+
+gboolean      gst_player_set_video_track              (GstPlayer    *player,
+                                                       gint stream_index);
+
+gboolean      gst_player_set_subtitle_track           (GstPlayer    *player,
+                                                       gint stream_index);
+
+GstPlayerMediaInfo * gst_player_get_media_info        (GstPlayer    * player);
+
+GstPlayerAudioInfo * gst_player_get_current_audio_track
+                                                      (GstPlayer    * player);
+
+GstPlayerVideoInfo * gst_player_get_current_video_track
+                                                      (GstPlayer    * player);
+
+GstPlayerSubtitleInfo * gst_player_get_current_subtitle_track
+                                                      (GstPlayer    * player);
 
 G_END_DECLS
 


### PR DESCRIPTION
Changes since v3:

* g_return_val_if_fail() whenever function has a non-void return type
* initialize the bitrate, max_bitrate to -1.
* use else if(...) statement when checking stream info types.
* copy the missing duration field in gst_player_media_info_copy (ref).
* add uri NULL assertion in gst_player_media_info_new (uri).
* create three Glists to cache the stream type.
* make media specific get_stream_list to (transfer none). The function will simply return the cached stream type list.
* remove the stream_info_free_list (). We no longer need it after making media specific get_stream_list to (transfer none).
* unref the temporary GstPad in get_caps()
* simplify the emit_media_info_updated_signal ()
  * create the new media info inside the function
  * send this newly created media_info object to user app.
  * unref the newly created media_info object in signal finalize method.
* rename gst_player_get_*_track to gst_player_get_current_*_track()
