### PR TITLE
build: remove the use of GST_PKG_CONFIG_PATH

### DIFF
--- a/lib/gst/player/Makefile.am
+++ b/lib/gst/player/Makefile.am
@@ -39,8 +39,7 @@ gir_headers=$(patsubst %,$(srcdir)/%, $(libgstplayer_HEADERS))
 gir_sources=$(patsubst %,$(srcdir)/%, $(libgstplayer_@GST_PLAYER_API_VERSION@_la_SOURCES))
 
 GstPlayer-@GST_PLAYER_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstplayer-@GST_PLAYER_API_VERSION@.la
-	$(AM_V_GEN)PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" \
-		$(INTROSPECTION_SCANNER) -v --namespace GstPlayer \
+	$(AM_V_GEN)$(INTROSPECTION_SCANNER) -v --namespace GstPlayer \
 		--nsversion=@GST_PLAYER_API_VERSION@ \
 		--warn-all \
 		--strip-prefix=Gst \


### PR DESCRIPTION
In gstreamer, that variable is defined in common/ submodule. But it is not
used here. As GST_PKG_CONFIG_PATH is not defined, it resets the
PKG_CONFIG_PATH breaking the compilation in jhbuild.

This patch removes the PKG_CONFIG_PATH assignation when launching the gir
scanner.