### PR TITLE
gtk-play: display cover art

### DIFF
--- a/gtk/gtk-play.c
+++ b/gtk/gtk-play.c
@@ -141,17 +141,11 @@ play_pause_clicked_cb (GtkButton * button, GtkPlay * play)
     gtk_button_set_image (GTK_BUTTON (play->play_pause_button), image);
     play->playing = FALSE;
   } else {
-    gchar *title;
-
     gst_player_play (play->player);
     image =
         gtk_image_new_from_icon_name ("media-playback-pause",
         GTK_ICON_SIZE_BUTTON);
     gtk_button_set_image (GTK_BUTTON (play->play_pause_button), image);
-
-    title = gst_player_get_uri (play->player);
-    set_title (play, title);
-    g_free (title);
     play->playing = TRUE;
   }
 }


### PR DESCRIPTION
We maintain two drawing widgets, image and video. Cover art is drawn in
image widget and video is rendered in video widget. Based on the following
conditions we show either image or video widget:

- if media info does not have active video stream then hide video widget
  and show image widget.
- if media info contains active video stream then show video widget and
  hide the image widget.