### PR TITLE
add external subtitle

### DIFF
--- a/docs/lib/gst-player-sections.txt
+++ b/docs/lib/gst-player-sections.txt
@@ -52,6 +52,10 @@ gst_player_get_current_subtitle_track
 gst_player_set_audio_track_enabled
 gst_player_set_video_track_enabled
 gst_player_set_subtitle_track_enabled
+
+gst_player_set_subtitle_uri
+gst_player_get_subtitle_uri
+
 <SUBSECTION Standard>
 GST_IS_PLAYER
 GST_IS_PLAYER_CLASS

--- a/lib/gst/player/gstplayer.c
+++ b/lib/gst/player/gstplayer.c
@@ -50,6 +50,8 @@
 #include <gst/tag/tag.h>
 #include <gst/pbutils/descriptions.h>
 
+#include <libgen.h> /* basename () */
+
 GST_DEBUG_CATEGORY_STATIC (gst_player_debug);
 #define GST_CAT_DEFAULT gst_player_debug
 
@@ -69,6 +71,7 @@ enum
   PROP_0,
   PROP_DISPATCH_TO_MAIN_CONTEXT,
   PROP_URI,
+  PROP_SUBURI,
   PROP_POSITION,
   PROP_DURATION,
   PROP_MEDIA_INFO,
@@ -110,6 +113,7 @@ struct _GstPlayer
   GMainContext *application_context;
 
   gchar *uri;
+  gchar *suburi;
 
   GThread *thread;
   GMutex lock;
@@ -230,6 +234,9 @@ gst_player_class_init (GstPlayerClass * klass)
   param_specs[PROP_URI] = g_param_spec_string ("uri", "URI", "Current URI",
       NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
+  param_specs[PROP_SUBURI] = g_param_spec_string ("suburi", "Subtitle URI",
+      "Current Subtitle URI", NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
   param_specs[PROP_POSITION] =
       g_param_spec_uint64 ("position", "Position", "Current Position",
       0, G_MAXUINT64, 0, G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
@@ -331,6 +338,8 @@ gst_player_finalize (GObject * object)
   GST_TRACE_OBJECT (self, "Finalizing");
 
   g_free (self->uri);
+  if (self->suburi)
+    g_free (self->suburi);
   if (self->global_tags)
     gst_tag_list_unref (self->global_tags);
   if (self->application_context)
@@ -355,8 +364,42 @@ gst_player_set_uri_internal (gpointer user_data)
 
   g_object_set (self->playbin, "uri", self->uri, NULL);
 
+  /* if have suburi from previous playback then free it */
+  if (self->suburi) {
+    g_free (self->suburi);
+    self->suburi = NULL;
+    g_object_set (self->playbin, "suburi", NULL, NULL);
+  }
+
   g_mutex_unlock (&self->lock);
 
+  return G_SOURCE_REMOVE;
+}
+
+static gboolean
+gst_player_set_suburi_internal (gpointer user_data)
+{
+  GstPlayer *self = user_data;
+  GstClockTime position;
+
+  /* get current position */
+  position = gst_player_get_position (self);
+
+  gst_player_stop_internal (self);
+
+  g_mutex_lock (&self->lock);
+
+  GST_DEBUG_OBJECT (self, "Changing SUBURI to '%s'", GST_STR_NULL (self->suburi));
+
+  g_object_set (self->playbin, "uri", self->uri, NULL);
+  g_object_set (self->playbin, "suburi", self->suburi, NULL);
+
+  g_mutex_unlock (&self->lock);
+
+  /* seek to last position */
+  gst_player_seek (self, position);
+
+  GST_DEBUG_OBJECT (self, "done ..");
   return G_SOURCE_REMOVE;
 }
 
@@ -381,6 +424,18 @@ gst_player_set_property (GObject * object, guint prop_id,
       g_mutex_unlock (&self->lock);
 
       g_main_context_invoke (self->context, gst_player_set_uri_internal, self);
+      break;
+    }
+    case PROP_SUBURI:{
+      g_mutex_lock (&self->lock);
+      if (self->suburi)
+        g_free (self->suburi);
+
+      self->suburi = g_value_dup_string (value);
+      GST_DEBUG_OBJECT (self, "Set suburi=%s", self->suburi);
+      g_mutex_unlock (&self->lock);
+
+      g_main_context_invoke (self->context, gst_player_set_suburi_internal, self);
       break;
     }
     case PROP_VOLUME:
@@ -417,6 +472,13 @@ gst_player_get_property (GObject * object, guint prop_id,
       g_mutex_unlock (&self->lock);
       break;
       GST_TRACE_OBJECT (self, "Returning is-playing=%d",
+          g_value_get_boolean (value));
+      break;
+    case PROP_SUBURI:
+      g_mutex_lock (&self->lock);
+      g_value_set_string (value, self->suburi);
+      g_mutex_unlock (&self->lock);
+      GST_DEBUG_OBJECT (self, "Returning has-suburi=%d",
           g_value_get_boolean (value));
       break;
     case PROP_POSITION:{
@@ -1490,6 +1552,26 @@ gst_player_subtitle_info_update (GstPlayer * self,
         g_free (lang_code);
       }
     }
+
+    /* If we are still failed to find language name then check if external
+     * subtitle is loaded and compare the stream index between current sub
+     * stream index with our stream index and if matches then declare it as
+     * external subtitle and use the filename.
+     */
+    if (!info->language) {
+      gint text_index = -1;
+      gchar * suburi = NULL;
+
+      g_object_get (G_OBJECT (self->playbin), "current-suburi", &suburi, NULL);
+      if (suburi) {
+        g_object_get (G_OBJECT (self->playbin), "current-text", &text_index,
+            NULL);
+        if (text_index == gst_player_stream_info_get_index (stream_info))
+          info->language = g_strdup (basename (suburi));
+        g_free (suburi);
+      }
+    }
+
   } else {
     if (info->language) {
       g_free (info->language);
@@ -2838,6 +2920,48 @@ gst_player_set_subtitle_track_enabled (GstPlayer * self, gboolean enabled)
     player_clear_flag (self, GST_PLAY_FLAG_SUBTITLE);
 
   GST_DEBUG_OBJECT (self, "track is '%s'", enabled ? "Enabled" : "Disabled");
+}
+
+/*
+ * gst_player_set_subtitle_uri:
+ * @player: #GstPlayer instance
+ * @suburi: subtitle uri
+ *
+ * Set the subtitle uri.
+ */
+gboolean
+gst_player_set_subtitle_uri (GstPlayer * self, const gchar * suburi)
+{
+  g_return_val_if_fail (GST_IS_PLAYER (self), FALSE);
+  g_return_val_if_fail (suburi != NULL, FALSE);
+
+  g_mutex_lock (&self->lock);
+  if (self->suburi)
+    g_free (self->suburi);
+  self->suburi = g_strdup (suburi);
+  g_mutex_unlock (&self->lock);
+
+  gst_player_set_suburi_internal (self);
+
+  return TRUE;
+}
+
+/*
+ * gst_player_get_subtitle_uri:
+ * @player: #GstPlayer instance
+ *
+ * current subtitle uri
+ */
+gchar *
+gst_player_get_subtitle_uri (GstPlayer * self)
+{
+  gchar *val = NULL;
+
+  g_return_val_if_fail (GST_IS_PLAYER (self), NULL);
+
+  g_object_get (self, "suburi", &val, NULL);
+
+  return val;
 }
 
 #define C_ENUM(v) ((gint) v)

--- a/lib/gst/player/gstplayer.h
+++ b/lib/gst/player/gstplayer.h
@@ -97,22 +97,22 @@ void         gst_player_set_window_handle             (GstPlayer    * player,
 
 GstElement * gst_player_get_pipeline                  (GstPlayer    * player);
 
-void          gst_player_set_video_track_enabled      (GstPlayer    * player,
+void         gst_player_set_video_track_enabled       (GstPlayer    * player,
                                                        gboolean enabled);
 
-void          gst_player_set_audio_track_enabled      (GstPlayer    * player,
+void         gst_player_set_audio_track_enabled       (GstPlayer    * player,
                                                        gboolean enabled);
 
-void          gst_player_set_subtitle_track_enabled   (GstPlayer    * player,
+void         gst_player_set_subtitle_track_enabled    (GstPlayer    * player,
                                                        gboolean enabled);
 
-gboolean      gst_player_set_audio_track              (GstPlayer    *player,
+gboolean     gst_player_set_audio_track               (GstPlayer    *player,
                                                        gint stream_index);
 
-gboolean      gst_player_set_video_track              (GstPlayer    *player,
+gboolean     gst_player_set_video_track               (GstPlayer    *player,
                                                        gint stream_index);
 
-gboolean      gst_player_set_subtitle_track           (GstPlayer    *player,
+gboolean     gst_player_set_subtitle_track            (GstPlayer    *player,
                                                        gint stream_index);
 
 GstPlayerMediaInfo * gst_player_get_media_info        (GstPlayer    * player);
@@ -125,6 +125,10 @@ GstPlayerVideoInfo * gst_player_get_current_video_track
 
 GstPlayerSubtitleInfo * gst_player_get_current_subtitle_track
                                                       (GstPlayer    * player);
+
+gboolean     gst_player_set_subtitle_uri              (GstPlayer    * player,
+                                                       const gchar *uri);
+gchar *      gst_player_get_subtitle_uri              (GstPlayer    * player);
 
 G_END_DECLS
 


### PR DESCRIPTION
The patch adds external subtitle support. First patch are some cleanup code in gtk-play. There are two things i noticed (not sure if its bug or playbin limitations)

- playbin does not support adding external subtitle on-fly, hence we need to restart the pipeline after setting the uri. gtk-play takes care of this. 
- playbin (i.e subparse) not able to parse the language of external subtitle hence gst_player_subtitle_info_get_language() returns "NULL".
- it will be nice to know if there is any way (or tag flags) which we can use to identify the external vs in-stream subtitle.

