### PR TITLE
add visualization support

### DIFF
--- a/docs/lib/gst-player-sections.txt
+++ b/docs/lib/gst-player-sections.txt
@@ -56,6 +56,12 @@ gst_player_set_subtitle_track_enabled
 gst_player_set_subtitle_uri
 gst_player_get_subtitle_uri
 
+gst_player_get_visualization_elements_name
+gst_player_get_visualization_elements_description
+gst_player_get_current_visualization
+gst_player_set_visualization
+gst_player_set_visualization_enabled
+
 <SUBSECTION Standard>
 GST_IS_PLAYER
 GST_IS_PLAYER_CLASS

--- a/docs/lib/gst-player-sections.txt
+++ b/docs/lib/gst-player-sections.txt
@@ -52,6 +52,10 @@ gst_player_get_current_subtitle_track
 gst_player_set_audio_track_enabled
 gst_player_set_video_track_enabled
 gst_player_set_subtitle_track_enabled
+
+gst_player_set_subtitle_uri
+gst_player_get_subtitle_uri
+
 <SUBSECTION Standard>
 GST_IS_PLAYER
 GST_IS_PLAYER_CLASS

--- a/lib/gst/player/gstplayer.h
+++ b/lib/gst/player/gstplayer.h
@@ -97,22 +97,22 @@ void         gst_player_set_window_handle             (GstPlayer    * player,
 
 GstElement * gst_player_get_pipeline                  (GstPlayer    * player);
 
-void          gst_player_set_video_track_enabled      (GstPlayer    * player,
+void         gst_player_set_video_track_enabled       (GstPlayer    * player,
                                                        gboolean enabled);
 
-void          gst_player_set_audio_track_enabled      (GstPlayer    * player,
+void         gst_player_set_audio_track_enabled       (GstPlayer    * player,
                                                        gboolean enabled);
 
-void          gst_player_set_subtitle_track_enabled   (GstPlayer    * player,
+void         gst_player_set_subtitle_track_enabled    (GstPlayer    * player,
                                                        gboolean enabled);
 
-gboolean      gst_player_set_audio_track              (GstPlayer    *player,
+gboolean     gst_player_set_audio_track               (GstPlayer    *player,
                                                        gint stream_index);
 
-gboolean      gst_player_set_video_track              (GstPlayer    *player,
+gboolean     gst_player_set_video_track               (GstPlayer    *player,
                                                        gint stream_index);
 
-gboolean      gst_player_set_subtitle_track           (GstPlayer    *player,
+gboolean     gst_player_set_subtitle_track            (GstPlayer    *player,
                                                        gint stream_index);
 
 GstPlayerMediaInfo * gst_player_get_media_info        (GstPlayer    * player);
@@ -125,6 +125,10 @@ GstPlayerVideoInfo * gst_player_get_current_video_track
 
 GstPlayerSubtitleInfo * gst_player_get_current_subtitle_track
                                                       (GstPlayer    * player);
+
+gboolean     gst_player_set_subtitle_uri              (GstPlayer    * player,
+                                                       const gchar *uri);
+gchar *      gst_player_get_subtitle_uri              (GstPlayer    * player);
 
 G_END_DECLS
 

--- a/lib/gst/player/gstplayer.h
+++ b/lib/gst/player/gstplayer.h
@@ -130,6 +130,18 @@ gboolean     gst_player_set_subtitle_uri              (GstPlayer    * player,
                                                        const gchar *uri);
 gchar *      gst_player_get_subtitle_uri              (GstPlayer    * player);
 
+gchar **     gst_player_get_visualization_elements_name (void);
+
+gchar **     gst_player_get_visualization_elements_description (void);
+
+gboolean     gst_player_set_visualization             (GstPlayer    * player,
+                                                       const gchar *name);
+
+void         gst_player_set_visualization_enabled     (GstPlayer    * player,
+                                                       gboolean enabled);
+
+const gchar * gst_player_get_current_visualization    (GstPlayer    * player);
+
 G_END_DECLS
 
 #endif /* __GST_PLAYER_H__ */


### PR DESCRIPTION
please review the visualization patches and let me know if I am on right track. I could not find any easy way to query the list of visualization element in gstreamer hence used a bit unconventional method (i.e read the plugin metadata kclass and search for word "visualization") to get list of visualization element.

The code works like this:
- during init player create new audio-visualization object.
- application can call gst_player_get_visualization_list() to get list of available gstreamer visualization element.
- application can call gst_player_set_visualization (player, name) to set the visualization element and similarly gst_player_set_visualization_enabled(player, boolean) can be used for enabling and disabling the visualization.

The code is working and I am able to get the visualization and able to change to various elements etc but like video, audio and subtitle disabling and enabling on-the-fly does not work.