### PR TITLE
misc fixes

### DIFF
--- a/docs/lib/Makefile.am
+++ b/docs/lib/Makefile.am
@@ -25,7 +25,7 @@ DOC_MAIN_SGML_FILE=$(DOC_MODULE)-docs.xml
 DOC_SOURCE_DIR=$(top_srcdir)/lib
 
 # Extra options to pass to gtkdoc-scangobj. Not normally needed.
-SCANGOBJ_OPTIONS=--type-init-func="g_type_init();gst_init(&argc,&argv)"
+SCANGOBJ_OPTIONS=--type-init-func="gst_init(&argc,&argv)"
 
 # Extra options to supply to gtkdoc-scan.
 # e.g. SCAN_OPTIONS=--deprecated-guards="GTK_DISABLE_DEPRECATED"

--- a/lib/gst/player/gstplayer.c
+++ b/lib/gst/player/gstplayer.c
@@ -3219,10 +3219,10 @@ gst_player_update_visualization_list (void)
 /**
  * gst_player_visualizations_get:
  *
- * Returns: (transfer full) (array zero-terminated=1) (element-type
- *  GstPlayerVisualization*): a %NULL terminated array containing all
- *  available visualizations. Use gst_player_visualizations_free()
- *  after usage.
+ * Returns: (transfer full) (array zero-terminated=1)
+ *  (element-type Gst.PlayerVisualization): a %NULL terminated
+ *  array containing all available visualizations. Use
+ *  gst_player_visualizations_free() after usage.
  *
  */
 GstPlayerVisualization **


### PR DESCRIPTION
Several fixes minor fixes and improvements.

I still have "build: remove init function in symbol scanners" because the initialization of gstreamer is not required for the scanners, since all the gstreamer api is hidden to the api user.