### PR TITLE
player: channel's label is the haystack

### DIFF
--- a/lib/gst/player/gstplayer.c
+++ b/lib/gst/player/gstplayer.c
@@ -3425,7 +3425,7 @@ gst_player_color_balance_find_channel (GstPlayer * self,
       gst_color_balance_list_channels (GST_COLOR_BALANCE (self->playbin));
   for (l = channels; l; l = l->next) {
     channel = l->data;
-    if (g_strrstr (cb_channel_map[type].label, channel->label))
+    if (g_strrstr (channel->label, cb_channel_map[type].label))
       return channel;
   }
 


### PR DESCRIPTION
When searching for a specific color balance channel within the ones provided
by the element, the string haystack is the label for the element's channel,
and the string needle is what we are looking.

Thus, we can assign custom color balance elements rather than only playbin.