### PR TITLE
player: fix doc warning

### DIFF
--- a/lib/gst/player/gstplayer.c
+++ b/lib/gst/player/gstplayer.c
@@ -2978,6 +2978,8 @@ gst_player_get_current_subtitle_track (GstPlayer * self)
  * @player: #GstPlayer instance
  * @stream_index: stream index
  *
+ * Returns: %TRUE or %FALSE
+ *
  * Sets the audio track @stream_idex.
  */
 gboolean
@@ -3005,6 +3007,8 @@ gst_player_set_audio_track (GstPlayer * self, gint stream_index)
  * gst_player_set_video_track:
  * @player: #GstPlayer instance
  * @stream_index: stream index
+ *
+ * Returns: %TRUE or %FALSE
  *
  * Sets the video track @stream_index.
  */
@@ -3034,6 +3038,8 @@ gst_player_set_video_track (GstPlayer * self, gint stream_index)
  * gst_player_set_subtitle_track:
  * @player: #GstPlayer instance
  * @stream_index: stream index
+ *
+ * Returns: %TRUE or %FALSE
  *
  * Sets the subtitle strack @stream_index.
  */
@@ -3122,6 +3128,8 @@ gst_player_set_subtitle_track_enabled (GstPlayer * self, gboolean enabled)
  * gst_player_set_subtitle_uri:
  * @player: #GstPlayer instance
  * @uri: subtitle URI
+ *
+ * Returns: %TRUE or %FALSE
  *
  * Sets the external subtitle URI.
  */


### PR DESCRIPTION
./../lib/gst/player/gstplayer.c:2982: warning: Parameter description for
gst_player_set_audio_track::Returns is missing in source code comment
block.
../../lib/gst/player/gstplayer.c:3039: warning: Parameter description
for gst_player_set_subtitle_track::Returns is missing in source code
comment block.
../../lib/gst/player/gstplayer.c:3127: warning: Parameter description
for gst_player_set_subtitle_uri::Returns is missing in source code
comment block.
../../lib/gst/player/gstplayer.c:3010: warning: Parameter description
for gst_player_set_video_track::Returns is missing in source code
comment block.