### PR TITLE
Add playback rate support

### DIFF
--- a/docs/lib/gst-player-sections.txt
+++ b/docs/lib/gst-player-sections.txt
@@ -73,6 +73,9 @@ gst_player_has_color_balance
 gst_player_set_color_balance
 gst_player_get_color_balance
 
+gst_player_get_rate
+gst_player_set_rate
+
 <SUBSECTION Standard>
 GST_IS_PLAYER
 GST_IS_PLAYER_CLASS


### PR DESCRIPTION
Initial implementation of playback rate control support. I have modified gtk-play to add new menu option (Playback Speed) to select the playback rates (0.5, 1.0, 1.5, 2.0, 2.5 ... 4.0). I guess in future  we can add a playback rate slider to control the rate instead of menu option.. 