### PR TITLE
gtk-play: build toolbar from xml and css

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,11 @@ AC_SUBST(GLIB_PREFIX)
 GST_PREFIX="`$PKG_CONFIG --variable=prefix gstreamer-1.0`"
 AC_SUBST(GST_PREFIX)
 
-PKG_CHECK_MODULES(GTK, [gtk+-3.0], [have_gtk="yes"], [have_gtk="no"])
+PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= 3.14], [have_gtk="yes"], [have_gtk="no"])
 AM_CONDITIONAL(HAVE_GTK, test "x$have_gtk" != "xno")
+
+PKG_CHECK_MODULES(GMODULE, [gmodule-2.0], [have_gmodules="yes"], [have_modules="no"])
+AM_CONDITIONAL(HAVE_GMODULE, test "x$have_gmodules" != "xno")
 
 PKG_CHECK_MODULES(GTK_X11, [gtk+-x11-3.0 x11], [have_gtk_x11="yes"], [have_gtk_x11="no"])
 AM_CONDITIONAL(HAVE_GTK_X11, test "x$have_gtk_x11" != "xno")

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -1,10 +1,36 @@
 bin_PROGRAMS = gtk-play
 
-gtk_play_SOURCES = gtk-play.c
+gtk-play-resources.c: resources/gresources.xml \
+	resources/media_info_dialog.ui	\
+	resources/toolbar.css						\
+	resources/toolbar.ui
+	$(AM_V_GEN)												\
+	glib-compile-resources						\
+	--sourcedir=$(srcdir)/resources		\
+	--target=$@												\
+	--generate-source									\
+	--c-name as												\
+	$(srcdir)/resources/gresources.xml
+
+gtk-play-resources.h: resources/gresources.xml \
+	resources/media_info_dialog.ui	\
+	resources/toolbar.css						\
+	resources/toolbar.ui
+	$(AM_V_GEN)												\
+	glib-compile-resources  					\
+	--sourcedir=$(srcdir)/resources   \
+	--target=$@												\
+	--generate-header									\
+	--c-name as												\
+	$(srcdir)/resources/gresources.xml
+
+BUILT_SOURCES: gtk-play-resources.c gtk-play-resources.h
+
+gtk_play_SOURCES = gtk-play.c gtk-play-resources.c
 
 LDADD = $(top_builddir)/lib/gst/player/.libs/libgstplayer-@GST_PLAYER_API_VERSION@.la \
-	$(GSTREAMER_LIBS) $(GTK_LIBS) $(GTK_X11_LIBS) $(GLIB_LIBS) $(LIBM)
+	$(GSTREAMER_LIBS) $(GTK_LIBS) $(GTK_X11_LIBS) $(GLIB_LIBS) $(LIBM) $(GMODULE_LIBS)
 
-AM_CFLAGS = -I$(top_srcdir)/lib -I$(top_builddir)/lib $(GSTREAMER_CFLAGS) $(GTK_CFLAGS) $(GTK_X11_CFLAGS) $(GLIB_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir)/lib -I$(top_builddir)/lib $(GSTREAMER_CFLAGS) $(GTK_CFLAGS) $(GTK_X11_CFLAGS) $(GLIB_CFLAGS) $(GMODULE_CFLAGS)
 
-noinst_HEADERS =
+noinst_HEADERS = gtk-play-resources.h

--- a/gtk/resources/gresources.xml
+++ b/gtk/resources/gresources.xml
@@ -1,0 +1,11 @@
+<? xml version="1.0" encoding="UTF-8" ?>
+<gresources>
+  <gresource prefix="/ui">
+    <file>toolbar.ui</file>
+    <file>media_info_dialog.ui</file>
+  </gresource>
+  <gresource prefix="/css">
+    <file>toolbar.css</file>
+  </gresource>
+</gresources>
+

--- a/gtk/resources/media_info_dialog.ui
+++ b/gtk/resources/media_info_dialog.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
+<interface>
+  <requires lib="gtk+" version="3.10"/>
+  <object class="GtkTreeStore" id="tree">
+    <columns>
+      <!-- column-name gchararray1 -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkDialog" id="media_info_dialog">
+    <property name="name">media_info_dialog</property>
+    <property name="can_focus">False</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="media_info_dialog_button">
+                <property name="label" translatable="yes">Close</property>
+                <property name="name">media_info_dialog_button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <signal name="clicked" handler="media_info_dialog_button_clicked_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">5</property>
+                <property name="label" translatable="yes">Information about all the streams contains in your media. </property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="sw">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="margin_top">5</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="view">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="model">tree</property>
+                    <property name="headers_visible">False</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection" id="treeview-selection2"/>
+                    </child>
+                    <child>
+                      <object class="GtkTreeViewColumn" id="col">
+                        <property name="sizing">autosize</property>
+                        <property name="title" translatable="yes">col</property>
+                        <child>
+                          <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/gtk/resources/toolbar.css
+++ b/gtk/resources/toolbar.css
@@ -1,0 +1,26 @@
+* {
+  background-color: rgba(43,56,54,0.0);
+  padding: 0px; 
+}
+
+GtkLabel {
+  font-size: 10px;
+  color: #ffffff; 
+}
+
+#toolbar {
+  border-radius: 25px;
+  border: 3px solid #212B2A;
+  background: rgba(43,56,54,0.6);
+}
+
+GtkButton:hover {
+  border-radius: 45px;
+  background: rgba(43,56,54,1.0);
+  border: 1px solid #212B2A;
+}
+
+#title_label {
+  font-size: 12px;
+}
+

--- a/gtk/resources/toolbar.ui
+++ b/gtk/resources/toolbar.ui
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <!-- interface-css-provider-path controls.css -->
+  <object class="GtkImage" id="forward_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="pixel_size">30</property>
+    <property name="icon_name">gtk-media-forward</property>
+    <property name="icon_size">0</property>
+  </object>
+  <object class="GtkImage" id="fullscreen_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="pixel_size">25</property>
+    <property name="icon_name">view-fullscreen</property>
+    <property name="icon_size">0</property>
+  </object>
+  <object class="GtkImage" id="next_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="pixel_size">30</property>
+    <property name="icon_name">gtk-media-next</property>
+    <property name="icon_size">0</property>
+  </object>
+  <object class="GtkImage" id="pause_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="pixel_size">35</property>
+    <property name="icon_name">media-playback-pause</property>
+    <property name="icon_size">0</property>
+  </object>
+  <object class="GtkImage" id="play_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="xalign">0</property>
+    <property name="yalign">0</property>
+    <property name="pixel_size">35</property>
+    <property name="icon_name">gtk-media-play</property>
+    <property name="icon_size">0</property>
+  </object>
+  <object class="GtkImage" id="prev_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="pixel_size">30</property>
+    <property name="icon_name">gtk-media-previous</property>
+  </object>
+  <object class="GtkImage" id="restore_image">
+    <property name="name">restore_image</property>
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="pixel_size">25</property>
+    <property name="icon_name">view-restore</property>
+    <property name="icon_size">0</property>
+  </object>
+  <object class="GtkImage" id="rewind_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="pixel_size">30</property>
+    <property name="icon_name">gtk-media-rewind</property>
+  </object>
+  <object class="GtkBox" id="toolbar">
+    <property name="name">toolbar</property>
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="margin_bottom">5</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkBox" id="box1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">20</property>
+        <property name="margin_right">20</property>
+        <property name="spacing">9</property>
+        <child>
+          <object class="GtkLabel" id="elapshed_time">
+            <property name="name">elapshed_time</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="label" translatable="yes">00:00</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScale" id="seekbar">
+            <property name="name">seekbar</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="valign">center</property>
+            <property name="round_digits">1</property>
+            <property name="draw_value">False</property>
+            <signal name="value-changed" handler="seekbar_value_changed_cb" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="remain_time">
+            <property name="name">remain_time</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="label" translatable="yes">00:00</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkVolumeButton" id="volume_button">
+            <property name="name">volume_button</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <property name="relief">none</property>
+            <property name="focus_on_click">False</property>
+            <property name="orientation">vertical</property>
+            <property name="icons">audio-volume-muted
+audio-volume-high
+audio-volume-low
+audio-volume-medium</property>
+            <signal name="value-changed" handler="volume_button_value_changed_cb" swapped="no"/>
+            <child internal-child="plus_button">
+              <object class="GtkButton" id="volumebutton-plus_button1">
+                <property name="label" translatable="yes">+</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="relief">none</property>
+              </object>
+            </child>
+            <child internal-child="minus_button">
+              <object class="GtkButton" id="volumebutton-minus_button1">
+                <property name="label" translatable="yes">-</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="relief">none</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkToggleButton" id="fullscreen_button">
+            <property name="name">fullscreen_button</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="image">fullscreen_image</property>
+            <property name="relief">none</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
+            <signal name="toggled" handler="fullscreen_button_toggled_cb" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">-1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="title_label">
+        <property name="name">title_label</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_top">5</property>
+        <property name="justify">center</property>
+        <property name="wrap">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="box2">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="valign">center</property>
+        <property name="margin_left">20</property>
+        <property name="margin_right">20</property>
+        <property name="margin_bottom">10</property>
+        <child>
+          <object class="GtkBox" id="box4">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkButton" id="prev_button">
+                <property name="name">prev_button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <property name="image">prev_image</property>
+                <property name="relief">none</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <signal name="clicked" handler="prev_button_clicked_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="rewind_button">
+                <property name="name">rewind_button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="image">rewind_image</property>
+                <property name="relief">none</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <signal name="clicked" handler="rewind_button_clicked_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="play_pause_button">
+                <property name="name">play_pause_button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <property name="image">pause_image</property>
+                <property name="relief">none</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <signal name="clicked" handler="play_pause_button_clicked_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="forward_button">
+                <property name="name">forward_button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <property name="image">forward_image</property>
+                <property name="relief">none</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <signal name="clicked" handler="forward_button_clicked_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="next_button">
+                <property name="name">next_button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <property name="image">next_image</property>
+                <property name="relief">none</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <signal name="clicked" handler="next_button_clicked_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="rate_label">
+            <property name="name">rate_label</property>
+            <property name="width_request">40</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
+            <property name="justify">right</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
Added support to build the UI from glade generated xml files and also added support to apply css. This should help us to customize the looks and feel without making too much changes in C code. I am not UI designer by any stretch but here is what I was quickly able to customize. The toolbar now looks like this:

![screenshot from 2015-06-26 19 29 11](https://cloud.githubusercontent.com/assets/3385272/8389627/10977136-1c3a-11e5-8f52-f71e328e7104.png)

The code is fully function, also did some cleanup around the image area widget. Now toolbar is overlay on top of video which also let us get those cool transparent widget. If this looks good then next i was going to look into adding app menu (again possibly generate GMenu through glade) and move the functionality of popup into app menu. Let me know what you think  ?

Cleanup includes:
* remove the image_area widget - the main purpose of this was to test media info provided cover image logic and we know it works well. Now instead of display image in window, i simply set the pixbuf in title. So if window manager respects the title image then you should see the image in title.
* remove visual args. Now visualization is enabled by default and if you play audio then visualization will automatically enabled.
* For now remove the loop button, will find a new place of it once we add app menu support. But one can still enable the loop through command line args (e.g --loop flags)
* media info dialog is also generated from the xml. I was not able to get the treemodel working through glade hence part of media info is still done through C code. I will later look into it or if someone knows the glade ticks to make the treeview work then it will be really cool as it can help remove some more code.
* Autohide toolbar no longer need to be done when we are in fullscreen. The toolbar is auto hidden even in  normal mode (inspired from snappy)
* toolbar also prints label when playing > or < 1.0 rate.
