### PR TITLE
build : fix build error coming from gir scanner/compiler

### DIFF
--- a/lib/gst/player/Makefile.am
+++ b/lib/gst/player/Makefile.am
@@ -47,6 +47,7 @@ GstPlayer-@GST_PLAYER_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstplayer-@G
 		-I$(top_builddir)/lib \
 		--c-include "gst/player/player.h" \
 		--add-include-path=$(top_builddir)/lib \
+		--add-include-path=`$(PKG_CONFIG) --variable=girdir gstreamer-1.0` \ 
 		--library-path=$(top_builddir)/lib \
 		--library=libgstplayer-@GST_PLAYER_API_VERSION@.la \
 		--include=GObject-2.0 \
@@ -74,7 +75,11 @@ typelibsdir = $(libdir)/girepository-1.0/
 typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
 
 %.typelib: %.gir $(INTROSPECTION_COMPILER)
-	$(AM_V_GEN)$(INTROSPECTION_COMPILER) --includedir=$(srcdir)/lib --includedir=$(builddir)/lib $(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+	$(AM_V_GEN)$(INTROSPECTION_COMPILER) \
+		--includedir=$(srcdir)/lib \
+		--includedir=$(builddir)/lib \
+		--includedir=`$(PKG_CONFIG) --variable=girdir gstreamer-1.0` \ 
+		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
 
 CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
 endif


### PR DESCRIPTION
Build error comes from gir scanner/compiler like below if it can't find  Gst-1.0.gir.
To fix, add pkg-config --variable=girdir gstreamer-1.0 to search. 
Pls review.

Couldn't find include 'Gst-1.0.gir' (search path: ['../../../lib', 'gir-1.0', '/usr/share/gir-1.0', '/usr/share/gir-1.0', '/usr/share/gir-1.0'])
Makefile:808: recipe for target 'GstPlayer-0.0.gir' failed

GEN GstPlayer-0.0.typelib
Could not find GIR file 'Gst-1.0.gir'; check XDG_DATA_DIRS or use --includedir
error parsing file GstPlayer-0.0.gir: Failed to parse included gir Gst-1.0
Makefile:834: recipe for target 'GstPlayer-0.0.typelib' failed