### PR TITLE
qt: add new qml item to render media info sample

### DIFF
--- a/qt/imagesample.cpp
+++ b/qt/imagesample.cpp
@@ -1,0 +1,41 @@
+#include <QPainter>
+#include "imagesample.h"
+
+ImageSample::ImageSample()
+    : QQuickPaintedItem()
+    , sample_()
+{
+
+}
+
+ImageSample::~ImageSample()
+{
+
+}
+
+void ImageSample::paint(QPainter *painter)
+{
+    if (sample_.size().isEmpty())
+        return;
+
+    float aspect_ratio = sample_.width() / sample_.height();
+    int w  = height() * aspect_ratio;
+    int x = (width() - w) / 2;
+
+    painter->setViewport(x, 0, w, height());
+    painter->drawImage(QRectF(0, 0, width(), height()), sample_);
+}
+
+const QImage &ImageSample::sample() const
+{
+    return sample_;
+}
+
+void ImageSample::setSample(const QImage &sample)
+{
+    sample_ = sample;
+    update();
+}
+
+
+

--- a/qt/imagesample.cpp
+++ b/qt/imagesample.cpp
@@ -1,3 +1,23 @@
+/* GStreamer
+ *
+ * Copyright (C) 2015 Alexandre Moreno <alexmorenocano@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
 #include <QPainter>
 #include "imagesample.h"
 

--- a/qt/imagesample.h
+++ b/qt/imagesample.h
@@ -1,0 +1,26 @@
+#ifndef IMAGESAMPLE_H
+#define IMAGESAMPLE_H
+
+#include <QObject>
+#include <QQuickPaintedItem>
+#include <QImage>
+#include <QPainter>
+#include "player.h"
+
+class ImageSample : public QQuickPaintedItem
+{
+    Q_OBJECT
+    Q_PROPERTY(QImage sample READ sample WRITE setSample)
+public:
+    ImageSample();
+    ~ImageSample();
+    void paint(QPainter *painter);
+
+    const QImage &sample() const;
+    void setSample(const QImage &sample);
+
+private:
+    QImage sample_;
+};
+
+#endif // IMAGESAMPLE_H

--- a/qt/imagesample.h
+++ b/qt/imagesample.h
@@ -1,3 +1,23 @@
+/* GStreamer
+ *
+ * Copyright (C) 2015 Alexandre Moreno <alexmorenocano@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
 #ifndef IMAGESAMPLE_H
 #define IMAGESAMPLE_H
 

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -25,6 +25,7 @@
 #include <QUrl>
 
 #include "player.h"
+#include "imagesample.h"
 
 int main(int argc, char *argv[])
 {
@@ -45,6 +46,7 @@ int main(int argc, char *argv[])
     }
 
     qmlRegisterType<Player>("Player", 1, 0, "Player");
+    qmlRegisterType<ImageSample>("ImageSample", 1, 0, "ImageSample");
 
     /* the plugin must be loaded before loading the qml file to register the
      * GstGLVideoItem qml item

--- a/qt/main.qml
+++ b/qt/main.qml
@@ -25,6 +25,7 @@ import QtQuick.Dialogs 1.2
 import QtQuick.Window 2.1
 import Player 1.0
 import org.freedesktop.gstreamer.GLVideoItem 1.0
+import ImageSample 1.0
 
 import "fontawesome.js" as FontAwesome
 
@@ -50,6 +51,7 @@ ApplicationWindow {
                 playbutton.state = "play"
             }
         }
+
         onResolutionChanged: {
             if (player.videoAvailable) {
                 window.width = resolution.width
@@ -64,6 +66,16 @@ ApplicationWindow {
         anchors.centerIn: parent
         width: parent.width
         height: parent.height
+        visible: player.videoAvailable
+    }
+
+    ImageSample {
+        id: sample
+        anchors.centerIn: parent
+        sample: player.mediaInfo.sample
+        width: parent.width
+        height: parent.height
+        visible: !player.videoAvailable
     }
 
     MouseArea {

--- a/qt/play.pro
+++ b/qt/play.pro
@@ -41,13 +41,15 @@ macx {
 HEADERS += \
     qgstplayer.h \
     player.h \
-    quickrenderer.h
+    quickrenderer.h \
+    imagesample.h
 
 SOURCES += main.cpp \
     qgstplayer.cpp \
     ../lib/gst/player/gstplayer.c \
     ../lib/gst/player/gstplayer-media-info.c \
     player.cpp \
-    quickrenderer.cpp
+    quickrenderer.cpp \
+    imagesample.cpp
 
 DISTFILES +=

--- a/qt/qgstplayer.h
+++ b/qt/qgstplayer.h
@@ -27,6 +27,7 @@
 //#include <QtGui/qwindowdefs.h>
 #include <QVariant>
 #include <QList>
+#include <QImage>
 #include <gst/player/player.h>
 
 namespace QGstPlayer {
@@ -174,6 +175,7 @@ class MediaInfo : public QObject
     Q_PROPERTY(QList<QObject*> videoStreams READ videoStreams CONSTANT)
     Q_PROPERTY(QList<QObject*> audioStreams READ audioStreams CONSTANT)
     Q_PROPERTY(QList<QObject*> subtitleStreams READ subtitleStreams CONSTANT)
+    Q_PROPERTY(QImage sample READ sample NOTIFY sampleChanged)
 
 public:
     explicit MediaInfo(Player *player = 0);
@@ -183,11 +185,13 @@ public:
     const QList<QObject*> &videoStreams() const;
     const QList<QObject*> &audioStreams() const;
     const QList<QObject*> &subtitleStreams() const;
+    const QImage &sample();
 
 signals:
     void uriChanged();
     void seekableChanged();
     void titleChanged();
+    void sampleChanged();
 
 public Q_SLOTS:
     void update(GstPlayerMediaInfo *info);
@@ -198,6 +202,7 @@ private:
     QList<QObject*> videoStreams_;
     QList<QObject*> audioStreams_;
     QList<QObject*> subtitleStreams_;
+    QImage sample_;
 };
 
 class StreamInfo : public QObject
@@ -267,6 +272,7 @@ private:
 
 Q_DECLARE_METATYPE(QGstPlayer::Player*)
 Q_DECLARE_METATYPE(QGstPlayer::Player::State)
+Q_DECLARE_METATYPE(QGstPlayer::MediaInfo*)
 
 extern "C" {
 


### PR DESCRIPTION
when video is not available it will try to display the sample image
returned by media info object.

<img width="1072" alt="screen shot 2015-11-02 at 01 53 37" src="https://cloud.githubusercontent.com/assets/3168575/10870381/9f3cc38a-8104-11e5-905c-1f4e47afb5ce.png">
