### PR TITLE
gtk-play: change print format of guint64

### DIFF
--- a/gtk/gtk-play.c
+++ b/gtk/gtk-play.c
@@ -1521,9 +1521,9 @@ update_position_label (GtkLabel * label, guint64 seconds)
   seconds -= mins * 60;
 
   if (hrs)
-    data = g_strdup_printf ("%d:%02d:%02ld", hrs, mins, seconds);
+    data = g_strdup_printf ("%d:%02d:%02" G_GUINT64_FORMAT, hrs, mins, seconds);
   else
-    data = g_strdup_printf ("%02d:%02ld", mins, seconds);
+    data = g_strdup_printf ("%02d:%02" G_GUINT64_FORMAT, mins, seconds);
 
   gtk_label_set_label (label, data);
   g_free (data);


### PR DESCRIPTION
guint64 type usually corresponds with 'G_GUINT64_FORMAT'.

With -Werror=format option of gcc, it complains mismatched type format like this;

```
  CC       gtk-play.o
gtk-play.c: In function ‘update_position_label’:
gtk-play.c:1524:29: error: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘guint64 {aka long long unsigned int}’ [-Werror=format=]
     data = g_strdup_printf ("%d:%02d:%02ld", hrs, mins, seconds);
                             ^
gtk-play.c:1526:29: error: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘guint64 {aka long long unsigned int}’ [-Werror=format=]
     data = g_strdup_printf ("%02d:%02ld", mins, seconds);
                             ^
```