### PR TITLE
gtk-play: provide similar behaviour for quit and close

### DIFF
--- a/gtk/gtk-play.c
+++ b/gtk/gtk-play.c
@@ -177,7 +177,7 @@ load_from_builder (const gchar * filename, gboolean register_sig_handler,
 static void
 delete_event_cb (GtkWidget * widget, GdkEvent * event, GtkPlay * play)
 {
-  gst_player_stop (play->player);
+  gtk_widget_destroy (GTK_WIDGET (play));
 }
 
 static void


### PR DESCRIPTION
In x86 targets, gtk-play just pause rather than quitting the application
when we click the close button (delete-event). Change the callback function
to get similar behaviour when we click on "Quit" menu option.

Signed-off-by: Maxin B. John <maxin.john@intel.com>